### PR TITLE
add support for ranging angles and elevation

### DIFF
--- a/uwbmodule/src/androidMain/kotlin/MultiplatformUwbManager.android.kt
+++ b/uwbmodule/src/androidMain/kotlin/MultiplatformUwbManager.android.kt
@@ -19,7 +19,7 @@ import kotlinx.coroutines.launch
 actual class MultiplatformUwbManager(private val androidUwbManager: UwbManager? = null) {
     private val TAG = "UwbManager"
 
-    private var rangingCallback: ((String, Double) -> Unit)? = null
+    private var rangingCallback: ((String, Double, Double?, Double?) -> Unit)? = null
     private var errorCallback: ((String) -> Unit)? = null
     private val coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
 
@@ -111,7 +111,10 @@ actual class MultiplatformUwbManager(private val androidUwbManager: UwbManager? 
                     updateRateType = RangingParameters.RANGING_UPDATE_RATE_AUTOMATIC
                 )
 
-                Log.d(TAG, "Starting ranging with $peerId — session=$agreedSessionId ch=${remoteConfig.channel}")
+                Log.d(
+                    TAG,
+                    "Starting ranging with $peerId — session=$agreedSessionId ch=${remoteConfig.channel}"
+                )
 
                 scope.prepareSession(rangingParameters)
                     .catch { exception ->
@@ -122,9 +125,15 @@ actual class MultiplatformUwbManager(private val androidUwbManager: UwbManager? 
                             is RangingResult.RangingResultPosition -> {
                                 val distance = result.position.distance?.value
                                 if (distance != null) {
-                                    rangingCallback?.invoke(peerId, distance.toDouble())
+                                    rangingCallback?.invoke(
+                                        peerId,
+                                        distance.toDouble(),
+                                        result.position.azimuth?.value?.toDouble(),
+                                        result.position.elevation?.value?.toDouble()
+                                    )
                                 }
                             }
+
                             is RangingResult.RangingResultPeerDisconnected -> {
                                 errorCallback?.invoke("Peer $peerId disconnected")
                                 activeJobs.remove(peerId)
@@ -146,7 +155,7 @@ actual class MultiplatformUwbManager(private val androidUwbManager: UwbManager? 
         }
     }
 
-    actual fun setRangingCallback(callback: (peerId: String, distance: Double) -> Unit) {
+    actual fun setRangingCallback(callback: (peerId: String, distance: Double, azimuth: Double?, elevation: Double?) -> Unit) {
         rangingCallback = callback
     }
 

--- a/uwbmodule/src/commonMain/kotlin/DeviceDiscoveryManager.kt
+++ b/uwbmodule/src/commonMain/kotlin/DeviceDiscoveryManager.kt
@@ -15,7 +15,6 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-//import androidx.core.uwb.RangingResult
 
 /**
  * Types of lifecycle events emitted during discovery → ranging.

--- a/uwbmodule/src/commonMain/kotlin/DeviceDiscoveryManager.kt
+++ b/uwbmodule/src/commonMain/kotlin/DeviceDiscoveryManager.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+//import androidx.core.uwb.RangingResult
 
 /**
  * Types of lifecycle events emitted during discovery → ranging.
@@ -37,6 +38,7 @@ data class DiscoveryEvent(
     val peerId: String,
     val message: String
 )
+
 
 /**
  * Orchestrates the full device discovery → BLE config exchange → UWB ranging pipeline.
@@ -88,8 +90,8 @@ class DeviceDiscoveryManager(
             scope.launch { onConfigExchanged(peerId, remoteConfig) }
         }
 
-        multiplatformUwbManager.setRangingCallback { peerId, distance ->
-            scope.launch { onRangingResult(peerId, distance) }
+        multiplatformUwbManager.setRangingCallback { peerId , distance , azimuth, elevation ->
+            scope.launch { onRangingResult(peerId, distance, azimuth, elevation ) }
         }
 
         multiplatformUwbManager.setErrorCallback { error ->
@@ -258,13 +260,15 @@ class DeviceDiscoveryManager(
     }
 
     /** Called when UWB ranging data is received. */
-    internal suspend fun onRangingResult(peerId: String, distance: Double) = mutex.withLock {
+    internal suspend fun onRangingResult(peerId: String, distance: Double, azimuth: Double?, elevation: Double?) = mutex.withLock {
         val existingDevices = _nearbyDevices.value.toMutableList()
         val deviceIndex = existingDevices.indexOfFirst { it.id == peerId }
 
-        if (deviceIndex != -1) {
-            existingDevices[deviceIndex] = existingDevices[deviceIndex].copy(
+        if (deviceIndex != -1) {                        
+            existingDevices[deviceIndex] = existingDevices[deviceIndex].copy(                
                 distance = distance,
+                azimuth = azimuth,
+                elevation = elevation,
                 lastSeen = getCurrentTimeMillis(),
                 state = DeviceState.Ranging
             )

--- a/uwbmodule/src/commonMain/kotlin/MultiplatformUwbManager.kt
+++ b/uwbmodule/src/commonMain/kotlin/MultiplatformUwbManager.kt
@@ -34,7 +34,7 @@ expect class MultiplatformUwbManager {
     fun stopRanging(peerId: String)
 
     /** Register callback for ranging distance updates. */
-    fun setRangingCallback(callback: (peerId: String, distance: Double) -> Unit)
+    fun setRangingCallback(callback: (peerId: String, distance: Double, azimuth: Double?, elevation: Double?) -> Unit)
 
     /** Register callback for errors. */
     fun setErrorCallback(callback: (error: String) -> Unit)

--- a/uwbmodule/src/commonMain/kotlin/NearbyDevice.kt
+++ b/uwbmodule/src/commonMain/kotlin/NearbyDevice.kt
@@ -27,6 +27,8 @@ data class NearbyDevice(
     val id: String,
     val name: String,
     val distance: Double? = null,
+    val azimuth: Double? = null,
+    val elevation: Double? = null,
     val lastSeen: Long = getCurrentTimeMillis(),
     val state: DeviceState = DeviceState.Discovered,
     val errorMessage: String? = null,

--- a/uwbmodule/src/iosMain/kotlin/MultiplatformUwbManager.ios.kt
+++ b/uwbmodule/src/iosMain/kotlin/MultiplatformUwbManager.ios.kt
@@ -122,46 +122,6 @@ actual class MultiplatformUwbManager {
         // Create a peer configuration with the exchanged token
         val config = NINearbyPeerConfiguration(peerToken)
 
-
-        /* on IOS, for required camera convergence in ios16+ on supported phones, iPhone 14+ 
-
-        first byte of data from remote device identifies data content
-
-        case .accessoryConfigurationData:
-        let message = data.advanced(by: 1)
-
-        setupAccessory(message, name: accessoryName, deviceID: deviceID)
-
-         func setupAccessory(_ configData: Data, name: String, deviceID: Int) {
-
-    
-        do {
-            accessory.configuration = try NINearbyAccessoryConfiguration(data: configData) <--- similar to above
-
-            if(!(NISession.deviceCapabilities.supportsDirectionMeasurement)){
-
-                NSLog("UwbManager - device does not support direction measurement");
-
-                if(NISession.deviceCapabilities.supportsCameraAssistance){
-
-                    NSLog("UwbManager - device DOES support camera assistance, requesting assistance")
-                    accessory.configuration?.isCameraAssistanceEnabled = true
-                } else {
-                    NSLog("UwbManager - device DOES NOT support camera assistance")
-                }
-            } else {
-                 NSLog("UwbManager - device DOES support direction measurement");
-            }
-
-        }
-        catch {
-            // Stop and display the issue because the incoming data is invalid.
-            // In your app, debug the accessory data to ensure an expected
-            // format.
-            return
-        } */
-
-
         NSLog("UwbManager: Starting ranging with $peerId")
         session.runWithConfiguration(config)
     }
@@ -253,60 +213,16 @@ actual class MultiplatformUwbManager {
             didUpdateAlgorithmConvergence: NIAlgorithmConvergence,
             forObject: NINearbyObject?
         ) {
-            // Algorithm convergence update — NOT informational
+            // Algorithm convergence update — informational
             when (didUpdateAlgorithmConvergence.status){
                 NIAlgorithmConvergenceStatus.NIAlgorithmConvergenceStatusConverged -> print("converged")
 
                 NIAlgorithmConvergenceStatus.NIAlgorithmConvergenceStatusNotConverged-> {
                     print("not converged")
-                    when (didUpdateAlgorithmConvergence.status) {
-
-                      /*  NIAlgorithmConvergenceStatus.entries.toTypedArray().first { insufficientLighting }   -> print("more light")
-
-                        NIAlgorithmConvergenceStatus.Reason.insufficientHorizontalSweep -> print("move left/right")
-
-                        NIAlgorithmConvergenceStatus.Reason.insufficientVerticalSweep -> print("move up/down") */
-
-                        else -> print("unexpected status")
-                    }
+                 
                 }
-                else -> print("oops")
-
-            }
-            /*  switch convergence.status {
-                case .converged:
-                    print("Horizontal Angle: \(String(describing: accessory.horizontalAngle))")
-                    print("verticalDirectionEstimate: \(accessory.verticalDirectionEstimate)")
-                    //infoLabelUpdate(with: "Converged")
-                    updatedDevice.isConverged = true
-                    break;
-                case .notConverged([NIAlgorithmConvergenceStatus.Reason.insufficientLighting]):
-                    print("not converged: More light required")
-                    updatedDevice.isConverged = false
-                    let parms = ["name": accessoryMap[accessory.discoveryToken] ?? "Unknown",
-                             "type": "PositionStatus",
-                             "message":" Insufficient Lighting"
-                    ]
-                    self.NotifyCallback!("UWBInfo", parms );
-                    break;
-                default:
-                    print(" not converged")//infoLabelUpdate(with: "Try moving in a different direction...")
-                    var message="" 
-                    switch(convergence.status){
-                        case .notConverged([NIAlgorithmConvergenceStatus.Reason.insufficientHorizontalSweep]):
-                           message = "need Horizontal Sweep"
-                        case .notConverged([NIAlgorithmConvergenceStatus.Reason.insufficientVerticalSweep]):   
-                           message = "need Vertical Sweep"
-                        default:
-                           message=""   
-                    }
-                    let parms = ["name": accessoryMap[accessory.discoveryToken] ?? "Unknown",
-                             "type": "PositionStatus",
-                             "message":message
-                    ] 
-                    // inform upper user that phone needs to move around
-                    self.NotifyCallback!("UWBInfo", parms );
-            } */
+                else -> print("oops, should only be converged or not")
+            }           
         }
 
         override fun sessionDidStartRunning(session: NISession) {

--- a/uwbmodule/src/iosMain/kotlin/MultiplatformUwbManager.ios.kt
+++ b/uwbmodule/src/iosMain/kotlin/MultiplatformUwbManager.ios.kt
@@ -8,6 +8,10 @@ import platform.Foundation.NSKeyedUnarchiver
 import platform.Foundation.NSLog
 import platform.NearbyInteraction.NIAlgorithmConvergence
 import platform.NearbyInteraction.NIAlgorithmConvergenceStatus
+import platform.NearbyInteraction.NIAlgorithmConvergenceStatusReasonInsufficientHorizontalSweep
+import platform.NearbyInteraction.NIAlgorithmConvergenceStatusReasonInsufficientLighting
+import platform.NearbyInteraction.NIAlgorithmConvergenceStatusReasonInsufficientMovement
+import platform.NearbyInteraction.NIAlgorithmConvergenceStatusReasonInsufficientVerticalSweep
 import platform.NearbyInteraction.NIDiscoveryToken
 import platform.NearbyInteraction.NINearbyObject
 import platform.NearbyInteraction.NINearbyObjectRemovalReason
@@ -213,16 +217,37 @@ actual class MultiplatformUwbManager {
             didUpdateAlgorithmConvergence: NIAlgorithmConvergence,
             forObject: NINearbyObject?
         ) {
-            // Algorithm convergence update — informational
-            when (didUpdateAlgorithmConvergence.status){
-                NIAlgorithmConvergenceStatus.NIAlgorithmConvergenceStatusConverged -> print("converged")
+            // Algorithm convergence update.
+            //
+            // NOTE: `NIAlgorithmConvergenceStatusReason` is NOT an enum — it is declared as
+            // `typedef NSString * NIAlgorithmConvergenceStatusReason NS_TYPED_ENUM`, so there is no
+            // type/enum-class to import. The reasons are NSString constants, and `convergence.reasons`
+            // (NSArray<NIAlgorithmConvergenceStatusReason>) comes through to Kotlin/Native as a
+            // List<*> of String. (The property is NS_SWIFT_UNAVAILABLE, but is exposed to K/N via the
+            // Obj-C surface.) We therefore compare the entries against the imported string constants.
+            when (didUpdateAlgorithmConvergence.status) {
+                NIAlgorithmConvergenceStatus.NIAlgorithmConvergenceStatusConverged ->
+                    NSLog("UwbManager: convergence converged — angles are valid")
 
-                NIAlgorithmConvergenceStatus.NIAlgorithmConvergenceStatusNotConverged-> {
-                    print("not converged")
-                 
+                NIAlgorithmConvergenceStatus.NIAlgorithmConvergenceStatusNotConverged -> {
+                    didUpdateAlgorithmConvergence.reasons.forEach { reason ->
+                        val message = when (reason as? String) {
+                            NIAlgorithmConvergenceStatusReasonInsufficientLighting ->
+                                "needs more light"
+                            NIAlgorithmConvergenceStatusReasonInsufficientHorizontalSweep ->
+                                "move device left/right"
+                            NIAlgorithmConvergenceStatusReasonInsufficientVerticalSweep ->
+                                "move device up/down"
+                            NIAlgorithmConvergenceStatusReasonInsufficientMovement ->
+                                "move around"
+                            else -> "try moving in a different direction"
+                        }
+                        NSLog("UwbManager: convergence not converged — $message")
+                    }
                 }
-                else -> print("oops, should only be converged or not")
-            }           
+
+                else -> NSLog("UwbManager: convergence status unknown")
+            }
         }
 
         override fun sessionDidStartRunning(session: NISession) {

--- a/uwbmodule/src/iosMain/kotlin/MultiplatformUwbManager.ios.kt
+++ b/uwbmodule/src/iosMain/kotlin/MultiplatformUwbManager.ios.kt
@@ -7,6 +7,7 @@ import platform.Foundation.NSKeyedArchiver
 import platform.Foundation.NSKeyedUnarchiver
 import platform.Foundation.NSLog
 import platform.NearbyInteraction.NIAlgorithmConvergence
+import platform.NearbyInteraction.NIAlgorithmConvergenceStatus
 import platform.NearbyInteraction.NIDiscoveryToken
 import platform.NearbyInteraction.NINearbyObject
 import platform.NearbyInteraction.NINearbyObjectRemovalReason
@@ -20,7 +21,7 @@ import platform.darwin.dispatch_get_main_queue
 @OptIn(ExperimentalForeignApi::class)
 actual class MultiplatformUwbManager {
     private var niSession: NISession? = null
-    private var rangingCallback: ((String, Double) -> Unit)? = null
+    private var rangingCallback: ((String, Double, Double?, Double?) -> Unit)? = null
     private var errorCallback: ((String) -> Unit)? = null
 
     /** Maps peer ID → the token we received from that peer. */
@@ -121,6 +122,46 @@ actual class MultiplatformUwbManager {
         // Create a peer configuration with the exchanged token
         val config = NINearbyPeerConfiguration(peerToken)
 
+
+        /* on IOS, for required camera convergence in ios16+ on supported phones, iPhone 14+ 
+
+        first byte of data from remote device identifies data content
+
+        case .accessoryConfigurationData:
+        let message = data.advanced(by: 1)
+
+        setupAccessory(message, name: accessoryName, deviceID: deviceID)
+
+         func setupAccessory(_ configData: Data, name: String, deviceID: Int) {
+
+    
+        do {
+            accessory.configuration = try NINearbyAccessoryConfiguration(data: configData) <--- similar to above
+
+            if(!(NISession.deviceCapabilities.supportsDirectionMeasurement)){
+
+                NSLog("UwbManager - device does not support direction measurement");
+
+                if(NISession.deviceCapabilities.supportsCameraAssistance){
+
+                    NSLog("UwbManager - device DOES support camera assistance, requesting assistance")
+                    accessory.configuration?.isCameraAssistanceEnabled = true
+                } else {
+                    NSLog("UwbManager - device DOES NOT support camera assistance")
+                }
+            } else {
+                 NSLog("UwbManager - device DOES support direction measurement");
+            }
+
+        }
+        catch {
+            // Stop and display the issue because the incoming data is invalid.
+            // In your app, debug the accessory data to ensure an expected
+            // format.
+            return
+        } */
+
+
         NSLog("UwbManager: Starting ranging with $peerId")
         session.runWithConfiguration(config)
     }
@@ -133,7 +174,7 @@ actual class MultiplatformUwbManager {
         }
     }
 
-    actual fun setRangingCallback(callback: (peerId: String, distance: Double) -> Unit) {
+    actual fun setRangingCallback(callback: (peerId: String, distance: Double, azimuth: Double?, elevation: Double?) -> Unit) {
         rangingCallback = callback
     }
 
@@ -157,12 +198,12 @@ actual class MultiplatformUwbManager {
         override fun session(session: NISession, didUpdateNearbyObjects: List<*>) {
             dispatchToMain {
                 didUpdateNearbyObjects.forEach { obj ->
-                    if (obj is NINearbyObject) {
+                    if (obj is NINearbyObject) {                        
                         val distance = obj.distance.toDouble()
                         if (!distance.isNaN()) {
                             val peerId = activePeers.entries
                                 .find { it.value == obj.discoveryToken }?.key ?: "unknown"
-                            rangingCallback?.invoke(peerId, distance)
+                            rangingCallback?.invoke(peerId, distance, obj.horizontalAngle().toDouble(), obj.verticalDirectionEstimate().toDouble())
                         }
                     }
                 }
@@ -212,7 +253,60 @@ actual class MultiplatformUwbManager {
             didUpdateAlgorithmConvergence: NIAlgorithmConvergence,
             forObject: NINearbyObject?
         ) {
-            // Algorithm convergence update — informational
+            // Algorithm convergence update — NOT informational
+            when (didUpdateAlgorithmConvergence.status){
+                NIAlgorithmConvergenceStatus.NIAlgorithmConvergenceStatusConverged -> print("converged")
+
+                NIAlgorithmConvergenceStatus.NIAlgorithmConvergenceStatusNotConverged-> {
+                    print("not converged")
+                    when (didUpdateAlgorithmConvergence.status) {
+
+                      /*  NIAlgorithmConvergenceStatus.entries.toTypedArray().first { insufficientLighting }   -> print("more light")
+
+                        NIAlgorithmConvergenceStatus.Reason.insufficientHorizontalSweep -> print("move left/right")
+
+                        NIAlgorithmConvergenceStatus.Reason.insufficientVerticalSweep -> print("move up/down") */
+
+                        else -> print("unexpected status")
+                    }
+                }
+                else -> print("oops")
+
+            }
+            /*  switch convergence.status {
+                case .converged:
+                    print("Horizontal Angle: \(String(describing: accessory.horizontalAngle))")
+                    print("verticalDirectionEstimate: \(accessory.verticalDirectionEstimate)")
+                    //infoLabelUpdate(with: "Converged")
+                    updatedDevice.isConverged = true
+                    break;
+                case .notConverged([NIAlgorithmConvergenceStatus.Reason.insufficientLighting]):
+                    print("not converged: More light required")
+                    updatedDevice.isConverged = false
+                    let parms = ["name": accessoryMap[accessory.discoveryToken] ?? "Unknown",
+                             "type": "PositionStatus",
+                             "message":" Insufficient Lighting"
+                    ]
+                    self.NotifyCallback!("UWBInfo", parms );
+                    break;
+                default:
+                    print(" not converged")//infoLabelUpdate(with: "Try moving in a different direction...")
+                    var message="" 
+                    switch(convergence.status){
+                        case .notConverged([NIAlgorithmConvergenceStatus.Reason.insufficientHorizontalSweep]):
+                           message = "need Horizontal Sweep"
+                        case .notConverged([NIAlgorithmConvergenceStatus.Reason.insufficientVerticalSweep]):   
+                           message = "need Vertical Sweep"
+                        default:
+                           message=""   
+                    }
+                    let parms = ["name": accessoryMap[accessory.discoveryToken] ?? "Unknown",
+                             "type": "PositionStatus",
+                             "message":message
+                    ] 
+                    // inform upper user that phone needs to move around
+                    self.NotifyCallback!("UWBInfo", parms );
+            } */
         }
 
         override fun sessionDidStartRunning(session: NISession) {


### PR DESCRIPTION
started adding support for angles and elevation on ranging.. 
because the 2 platform create different source objects/values, 
I change the rangingCallback to support the raw values, distance, azimuth and elevation
and added those to the device table

I added some of the IOS current model support for convergence and 
my existing code updates the config returned from the remote device, with the cameraAssistance needed
and that is what the NISession.run() is done against. 

some values are missing from the Nearby object for 
pending convergence, needing light, horizontal movement and vertical  movement. 
it appears those are bit values in the convergence status, see

didUpdateAlgorithmConvergence: NIAlgorithmConvergence,

i comment inserted my ios swift code (HW running QANI, not UCI firmware)  for that.. I don't see those values in the Nearby classes.  without convergence, only get distance.. 

I posted in the Qorvo forums about convergence 

from the apple dev docs


[Apple Developer Documentation](https://developer.apple.com/documentation/nearbyinteraction/initiating-and-maintaining-a-session)

[Initiating and maintaining a session | Apple Developer Documentation](https://developer.apple.com/documentation/nearbyinteraction/initiating-and-maintaining-a-session)
Measure the relative position of a nearby device and coach the user to sustain interaction.

[Increase line of sight with Camera Assistance](https://developer.apple.com/documentation/nearbyinteraction/initiating-and-maintaining-a-session#Increase-line-of-sight-with-Camera-Assistance)
In iOS 16, (sept 22, iPhone 14) , Camera Assistance ([isCameraAssistanceEnabled](https://developer.apple.com/documentation/nearbyinteraction/ninearbypeerconfiguration/iscameraassistanceenabled)) increases the device’s line of sight to a larger area that surrounds the device. This provides a nearby object’s [distance](https://developer.apple.com/documentation/nearbyinteraction/ninearbyobject/distance-676dm) and [direction](https://developer.apple.com/documentation/nearbyinteraction/ninearbyobject/direction-4qh5w) in a wider range of environmental conditions, in addition to the object’s [horizontalAngle](https://developer.apple.com/documentation/nearbyinteraction/ninearbyobject/horizontalangle-hsg) and [verticalDirectionEstimate](https://developer.apple.com/documentation/nearbyinteraction/ninearbyobject/verticaldirectionestimate-swift.property).

==============
Camera Assistance provides a [direction](https://developer.apple.com/documentation/nearbyinteraction/ninearbyobject/direction-4qh5w) outside of the narrow line of sight ===>only after first encountering the peer device once within the narrow line of sight. <==== (convergence, moving the phone around)
To use Camera Assistance in an interaction session, ensure the device supports the feature first by checking the value of [supportsCameraAssistance](https://developer.apple.com/documentation/nearbyinteraction/nidevicecapability/supportscameraassistance).

it does NOT mention, if you DON’T set cameraAssistance to true, then you ONLY get distance.
which killed our app functionality.

----- on my other hardware, mentioned in the issue, the phone doesn't range.  an intermediate device does the BLE scanning and UCI ranging under the covers. so the app is completely isolated from the OS.. just uses BLE to talk to the intermediate board. 

the app just gets the BLE  device scan results, and the start/stop ranging command results and the  UCI ranging status notifications. (NTFs)

I don't know if you want to invest in the non-UCI apple implementation, but I haven't seen any indication that they will go this way


.... doah, was looking a the java doc, not kotlin
the other thing is on the ranging status 
https://developer.android.com/reference/androidx/core/uwb/RangingPosition

says the Position, holds measurements, which have declared methods.  getDirection().... 
BUT not..
and if you look in https://developer.android.com/reference/androidx/core/uwb/RangingMeasurement
it has a function getValue()
BUT not.. 
there is a value operator on measurement, 

but the getAzimuth/Elevation are supposed to support the optional NULL if not present, but the value does not
Unless there is a kotlin side effect here
….
I have a UWB Pixel coming next week to see how this works.. 



