### PR TITLE
iOS angle guard, CI build fix, README updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,10 +9,11 @@ on:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest
-            task: compileKotlinAndroid
+            task: compileDebugKotlinAndroid
           - os: macos-latest
             task: compileKotlinIosSimulatorArm64
     runs-on: ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The library combines **Bluetooth Low Energy (BLE)** for initial device discovery
 
 - **BLE Device Discovery**: Automatic scanning and advertising for UWB-capable devices
 - **Precise UWB Ranging**: Real-time distance measurements with centimeter-level accuracy
+- **Angle of Arrival**: Azimuth/elevation alongside distance, where the hardware supports it. Currently functional on Android (devices with AoA-capable antennas); on iOS, azimuth requires iOS 16+ with Camera Assistance (work in progress — see below), and elevation is not exposed by NearbyInteraction
 - **Cross-Platform API**: Unified interface for both Android and iOS platforms
 - **Reactive Data Flow**: Kotlin Flow-based real-time updates for device discovery and ranging
 - **Permission Management**: Integrated permission handling for BLE and UWB access
@@ -304,7 +305,9 @@ Data class representing a discovered device.
 data class NearbyDevice(
     val id: String,
     val name: String,
-    val distance: Double? = null,
+    val distance: Double? = null,   // meters
+    val azimuth: Double? = null,    // horizontal angle; null when unavailable
+    val elevation: Double? = null,  // vertical angle; null when unavailable (always null on iOS)
     val lastSeen: Long
 )
 ```
@@ -317,7 +320,9 @@ expect class MultiplatformUwbManager {
     fun initialize()
     fun startRanging(peerId: String)
     fun stopRanging(peerId: String)
-    fun setRangingCallback(callback: (peerId: String, distance: Double) -> Unit)
+    fun setRangingCallback(
+        callback: (peerId: String, distance: Double, azimuth: Double?, elevation: Double?) -> Unit
+    )
     fun setErrorCallback(callback: (error: String) -> Unit)
 }
 ```

--- a/uwbmodule/src/iosMain/kotlin/MultiplatformUwbManager.ios.kt
+++ b/uwbmodule/src/iosMain/kotlin/MultiplatformUwbManager.ios.kt
@@ -1,11 +1,13 @@
 package com.dustedrob.uwb
 
 import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.useContents
 import platform.Foundation.NSData
 import platform.Foundation.NSError
 import platform.Foundation.NSKeyedArchiver
 import platform.Foundation.NSKeyedUnarchiver
 import platform.Foundation.NSLog
+import platform.Foundation.NSProcessInfo
 import platform.NearbyInteraction.NIAlgorithmConvergence
 import platform.NearbyInteraction.NIAlgorithmConvergenceStatus
 import platform.NearbyInteraction.NIAlgorithmConvergenceStatusReasonInsufficientHorizontalSweep
@@ -27,6 +29,13 @@ actual class MultiplatformUwbManager {
     private var niSession: NISession? = null
     private var rangingCallback: ((String, Double, Double?, Double?) -> Unit)? = null
     private var errorCallback: ((String) -> Unit)? = null
+
+    /**
+     * NearbyInteraction direction APIs (`horizontalAngle`, `verticalDirectionEstimate`) are iOS 16+.
+     * Calling them on iOS 14/15 is an unrecognized selector and crashes, so gate on the OS version.
+     */
+    private val directionApiAvailable: Boolean =
+        NSProcessInfo.processInfo.operatingSystemVersion.useContents { majorVersion >= 16 }
 
     /** Maps peer ID → the token we received from that peer. */
     private val activePeers = mutableMapOf<String, NIDiscoveryToken>()
@@ -162,12 +171,25 @@ actual class MultiplatformUwbManager {
         override fun session(session: NISession, didUpdateNearbyObjects: List<*>) {
             dispatchToMain {
                 didUpdateNearbyObjects.forEach { obj ->
-                    if (obj is NINearbyObject) {                        
+                    if (obj is NINearbyObject) {
                         val distance = obj.distance.toDouble()
                         if (!distance.isNaN()) {
                             val peerId = activePeers.entries
                                 .find { it.value == obj.discoveryToken }?.key ?: "unknown"
-                            rangingCallback?.invoke(peerId, distance, obj.horizontalAngle().toDouble(), obj.verticalDirectionEstimate().toDouble())
+
+                            // Azimuth (`horizontalAngle`) is iOS 16+ and is NaN until camera-assistance
+                            // convergence, so only emit it when available and valid.
+                            val azimuth: Double? =
+                                if (directionApiAvailable) {
+                                    obj.horizontalAngle.let { if (it.isNaN()) null else it.toDouble() }
+                                } else {
+                                    null
+                                }
+
+                            // NearbyInteraction exposes no elevation angle — `verticalDirectionEstimate`
+                            // is a direction category (above/below/same), not a measurement — so we
+                            // leave elevation null on iOS rather than emit a meaningless value.
+                            rangingCallback?.invoke(peerId, distance, azimuth, null)
                         }
                     }
                 }


### PR DESCRIPTION
Follow-up hardening after #3. Three low-risk fixes from an audit of `main`.

### 1. iOS: guard direction APIs (crash fix + correct semantics)
`didUpdateNearbyObjects` read `obj.horizontalAngle()` / `obj.verticalDirectionEstimate()` unconditionally, but both are **iOS 16+** APIs while the README promises iOS 14+. On iOS 14/15 these are unrecognized selectors → a runtime crash in the ranging callback, regressing distance ranging on older devices. (They were also written as method calls; `horizontalAngle` is a property, like `distance` right above it.)

This change:
- gates the direction APIs behind an iOS-16 OS-version check (`NSProcessInfo`)
- emits `azimuth` only when valid — `horizontalAngle` is `NaN` until camera-assistance convergence
- stops mapping `verticalDirectionEstimate` to `elevation`: it's a **direction category** (above/below/same), not an angle. iOS now reports `elevation = null` (NearbyInteraction exposes no elevation angle)

### 2. CI: the build never actually compiled
The `Build` workflow ran `./gradlew compileKotlinAndroid`, which is **ambiguous** and fails at task resolution before compiling anything (red on every commit since February). And `fail-fast` was cancelling the macOS iOS-compile job whenever the Android job failed — so the iOS code has never been compiled by CI at all.
- `compileKotlinAndroid` → `compileDebugKotlinAndroid`
- add `fail-fast: false`

### 3. Docs
- `NearbyDevice` and `setRangingCallback` examples updated for `azimuth`/`elevation` (4-arg callback)
- new "Angle of Arrival" feature note with platform caveats (Android AoA-hardware only; iOS azimuth needs iOS 16 + Camera Assistance, WIP; iOS has no elevation)
