### PR TITLE
Android: fix BLE advertise overflow and scan location requirement

### DIFF
--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -3,16 +3,21 @@
     <!-- Bluetooth permissions -->
     <uses-permission android:name="android.permission.BLUETOOTH" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
-    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
+    <!-- Scan filters by service UUID and never derives physical location, so we
+         assert neverForLocation; this frees Android 12+ from requiring Location
+         Services to be enabled for BLE scan results. -->
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN"
+        android:usesPermissionFlags="neverForLocation" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" />
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
-    
+
     <!-- UWB permission -->
     <uses-permission android:name="android.permission.UWB_RANGING" />
-    
-    <!-- Location permission (required for Bluetooth scanning) -->
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+
+    <!-- Location is only required for BLE scanning on Android 11 (API 30) and below;
+         on Android 12+ the neverForLocation flag above removes this requirement. -->
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"
+        android:maxSdkVersion="30" />
     
     <!-- Hardware features -->
     <uses-feature 

--- a/uwbmodule/src/androidMain/AndroidManifest.xml
+++ b/uwbmodule/src/androidMain/AndroidManifest.xml
@@ -3,10 +3,15 @@
 
     <uses-permission android:name="android.permission.BLUETOOTH" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
-    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
+    <!-- Scan filters by service UUID and never derives physical location, so we
+         assert neverForLocation; this frees Android 12+ from requiring Location
+         Services to be enabled for BLE scan results. -->
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN"
+        android:usesPermissionFlags="neverForLocation" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" />
     <uses-permission android:name="android.permission.UWB_RANGING" />
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <!-- Location is only required for BLE scanning on Android 11 (API 30) and below. -->
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"
+        android:maxSdkVersion="30" />
 
 </manifest>

--- a/uwbmodule/src/androidMain/kotlin/BleManager.kt
+++ b/uwbmodule/src/androidMain/kotlin/BleManager.kt
@@ -242,12 +242,23 @@ actual class BleManager(private val context: Context) {
                 .setConnectable(true)
                 .build()
 
+            // The primary advertisement carries only the service UUID. The device
+            // name goes in the scan response: a 128-bit service UUID already uses
+            // 18 of the 31-byte legacy advertisement budget, so including the name
+            // here too overflows it and fails with ADVERTISE_FAILED_DATA_TOO_LARGE
+            // (error code 1). This matters because UWB-interop UUIDs (Nordic UART,
+            // Qorvo NI) are full 128-bit values, unlike the base-UUID-derived FFF0
+            // which Android compresses to 2 bytes.
             val data = AdvertiseData.Builder()
-                .setIncludeDeviceName(true)
+                .setIncludeDeviceName(false)
                 .addServiceUuid(ParcelUuid(SERVICE_UUID))
                 .build()
 
-            advertiser.startAdvertising(settings, data, advertiseCallback)
+            val scanResponse = AdvertiseData.Builder()
+                .setIncludeDeviceName(true)
+                .build()
+
+            advertiser.startAdvertising(settings, data, scanResponse, advertiseCallback)
             Log.d(TAG, "BLE advertising started")
         } catch (e: Exception) {
             Log.e(TAG, "Error starting BLE advertising: ${e.message}")


### PR DESCRIPTION
## Summary

Two Android BLE fixes surfaced by @sdetweil while testing on a Pixel 6 Pro (#5). Both are prerequisites for the iOS-interop UUID work discussed in that issue.

### 1. Advertising overflow (`ADVERTISE_FAILED_DATA_TOO_LARGE`, error code 1)
The advertise builder included both the device name and the service UUID. A full 128-bit service UUID already consumes 18 of the 31-byte legacy advertisement budget, so including the name too overflows it.

**Fix:** keep only the service UUID in the primary advertisement and move the device name into the **scan response** packet, so the advertisement always fits even with 128-bit UUIDs.

### 2. Scan required Location Services on Android 12+
`BLUETOOTH_SCAN` was declared without `neverForLocation`, so on Android 12+ the OS required Location Services to be enabled for scan results to be returned (the "scanning failed, location was disabled" symptom).

Applied to both the `uwbmodule` library manifest and the `composeApp` app manifest.

## Testing
Local Gradle build could not run in this environment (pre-existing JDK/toolchain mismatch unrelated to these changes). Changes are a manifest edit plus the stable `startAdvertising(settings, advertiseData, scanResponse, callback)` overload (public since API 21). Recommend a quick on-device check on the Pixel 6 Pro: advertising should start without error 1, and scanning should return results with Location Services off.

Refs #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)