### PR TITLE
Multi-UUID profiles: fix config exchange + make profiles app-configurable

### DIFF
--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -3,7 +3,11 @@
     <!-- Bluetooth permissions -->
     <uses-permission android:name="android.permission.BLUETOOTH" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
-    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
+    <!-- Scan filters by service UUID and never derives physical location, so we
+         assert neverForLocation; this frees Android 12+ from requiring Location
+         Services to be enabled for BLE scan results. -->
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN"
+        android:usesPermissionFlags="neverForLocation" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" />
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
     
@@ -11,8 +15,10 @@
     <uses-permission android:name="android.permission.UWB_RANGING" />
     
     <!-- Location permission (required for Bluetooth scanning) -->
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <!-- Location is only required for BLE scanning on Android 11 (API 30) and below;
+         on Android 12+ the neverForLocation flag above removes this requirement. -->
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"
+        android:maxSdkVersion="30" />
     
     <!-- Hardware features -->
     <uses-feature 

--- a/uwbmodule/src/androidMain/AndroidManifest.xml
+++ b/uwbmodule/src/androidMain/AndroidManifest.xml
@@ -3,6 +3,7 @@
 
     <uses-permission android:name="android.permission.BLUETOOTH" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
     <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" />
     <uses-permission android:name="android.permission.UWB_RANGING" />

--- a/uwbmodule/src/androidMain/AndroidManifest.xml
+++ b/uwbmodule/src/androidMain/AndroidManifest.xml
@@ -9,6 +9,7 @@
     <uses-permission android:name="android.permission.BLUETOOTH_SCAN"
         android:usesPermissionFlags="neverForLocation" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
     <uses-permission android:name="android.permission.UWB_RANGING" />
     <!-- Location is only required for BLE scanning on Android 11 (API 30) and below. -->
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"

--- a/uwbmodule/src/androidMain/kotlin/BleManager.kt
+++ b/uwbmodule/src/androidMain/kotlin/BleManager.kt
@@ -105,6 +105,7 @@ actual class BleManager(private val context: Context) {
     // ---- GATT Server callback ----
 
     private val gattServerCallback = object : BluetoothGattServerCallback() {
+
         override fun onConnectionStateChange(device: BluetoothDevice, status: Int, newState: Int) {
             if (newState == BluetoothProfile.STATE_CONNECTED) {
                 Log.d(TAG, "GATT server: device connected: ${device.address}")
@@ -271,7 +272,7 @@ actual class BleManager(private val context: Context) {
             // which Android compresses to 2 bytes.
             val data = AdvertiseData.Builder()
                 .setIncludeDeviceName(false)
-                .addServiceUuid(ParcelUuid(SERVICE_UUID))
+                .addServiceUuid(ParcelUuid((UUID.fromString(GattUuids.find { it.name == GattName }?.discoveryServiceUUID?.uppercase()))))
                 .build()
 
             val scanResponse = AdvertiseData.Builder()

--- a/uwbmodule/src/androidMain/kotlin/BleManager.kt
+++ b/uwbmodule/src/androidMain/kotlin/BleManager.kt
@@ -29,12 +29,14 @@ import androidx.annotation.RequiresPermission
 import androidx.core.content.ContextCompat
 import java.util.UUID
 
+var GattName = "QorvoNearbyFixed"
 actual class BleManager(private val context: Context) {
     private val TAG = "BleManager"
 
-    private val SERVICE_UUID = UUID.fromString(GattUuids.UWB_DISCOVERY_SERVICE_UUID)
-    private val CONFIG_READ_UUID = UUID.fromString(GattUuids.UWB_CONFIG_CHAR_UUID)
-    private val CONFIG_WRITE_UUID = UUID.fromString(GattUuids.UWB_CONFIG_WRITE_CHAR_UUID)
+    private data class  accessoryDevice (
+        val bleDevice: BluetoothDevice? = null,
+        val service: ServiceEntry?=null
+    )
 
     private val bluetoothManager: BluetoothManager by lazy {
         context.getSystemService(Context.BLUETOOTH_SERVICE) as BluetoothManager
@@ -51,25 +53,36 @@ actual class BleManager(private val context: Context) {
     private var localConfig: UwbSessionConfig? = null
 
     // Track discovered peripherals for GATT client connections
-    private val discoveredDevices = mutableMapOf<String, BluetoothDevice>()
+    private val discoveredDevices = mutableMapOf<String, accessoryDevice>()
 
     // ---- Scan callback ----
 
     private val scanCallback = object : ScanCallback() {
+        @RequiresPermission(BLUETOOTH_CONNECT)
         override fun onScanResult(callbackType: Int, result: ScanResult) {
             val device = result.device
             val deviceAddress = device.address
+            var service: ServiceEntry? = null
             val deviceName = if (hasConnectPermission()) {
                 device.name ?: "Unknown Device"
             } else {
                 "Unknown Device"
             }
 
+            result.scanRecord?.serviceUuids?.forEach { uuid ->
+                GattUuids.forEach { serviceEntry ->
+                    if(serviceEntry.discoveryServiceUUID.uppercase() == uuid.toString().uppercase())
+                        if(service == null) {
+                            service = serviceEntry
+                        }
+                }
+            }
             // Cache the BluetoothDevice for later GATT connection
-            discoveredDevices[deviceAddress] = device
+            discoveredDevices[deviceAddress] = accessoryDevice(device,service)
 
             Log.d(TAG, "Found device: $deviceName ($deviceAddress)")
             deviceDiscoveredCallback?.invoke(deviceAddress, deviceName)
+
         }
 
         override fun onScanFailed(errorCode: Int) {
@@ -100,13 +113,15 @@ actual class BleManager(private val context: Context) {
             }
         }
 
+        @RequiresPermission(BLUETOOTH_CONNECT)
         override fun onCharacteristicReadRequest(
             device: BluetoothDevice,
             requestId: Int,
             offset: Int,
             characteristic: BluetoothGattCharacteristic
         ) {
-            if (characteristic.uuid == CONFIG_READ_UUID) {
+            var discoveredDevice= discoveredDevices[device.address]
+            if (characteristic.uuid.toString() == discoveredDevice?.service?.readFromUUID?.uppercase()) {
                 val configBytes = localConfig?.toByteArray() ?: ByteArray(0)
                 val responseBytes = if (offset < configBytes.size) {
                     configBytes.copyOfRange(offset, configBytes.size)
@@ -120,6 +135,7 @@ actual class BleManager(private val context: Context) {
             }
         }
 
+        @RequiresPermission(BLUETOOTH_CONNECT)
         override fun onCharacteristicWriteRequest(
             device: BluetoothDevice,
             requestId: Int,
@@ -129,7 +145,8 @@ actual class BleManager(private val context: Context) {
             offset: Int,
             value: ByteArray?
         ) {
-            if (characteristic.uuid == CONFIG_WRITE_UUID && value != null) {
+            var discoveredDevice= discoveredDevices[device.address]
+            if (characteristic.uuid.toString() == discoveredDevice?.service?.writeToUUID?.uppercase() && value != null) {
                 gattServer?.sendResponse(device, requestId, BluetoothGatt.GATT_SUCCESS, 0, null)
 
                 val remoteConfig = UwbSessionConfig.fromByteArray(value)
@@ -193,14 +210,17 @@ actual class BleManager(private val context: Context) {
             }
 
             val scanSettings = ScanSettings.Builder()
-                .setScanMode(ScanSettings.SCAN_MODE_LOW_LATENCY)
+                .setScanMode(ScanSettings.SCAN_MODE_LOW_LATENCY or ScanSettings.CALLBACK_TYPE_FIRST_MATCH)
                 .build()
 
-            val scanFilter = ScanFilter.Builder()
-                .setServiceUuid(ParcelUuid(SERVICE_UUID))
-                .build()
-
-            scanner.startScan(listOf(scanFilter), scanSettings, scanCallback)
+            var filters: MutableList<ScanFilter> = mutableListOf()
+            GattUuids.forEach { serviceEntry ->
+                val scanFilter = ScanFilter.Builder()
+                    .setServiceUuid(ParcelUuid(UUID.fromString(serviceEntry.discoveryServiceUUID.uppercase())))
+                    .build()
+                filters.add(scanFilter)
+            }
+            scanner.startScan(filters, scanSettings, scanCallback)
             Log.d(TAG, "BLE scanning started")
         } catch (e: Exception) {
             Log.e(TAG, "Error starting BLE scan: ${e.message}")
@@ -242,12 +262,23 @@ actual class BleManager(private val context: Context) {
                 .setConnectable(true)
                 .build()
 
+            // The primary advertisement carries only the service UUID. The device
+            // name goes in the scan response: a 128-bit service UUID already uses
+            // 18 of the 31-byte legacy advertisement budget, so including the name
+            // here too overflows it and fails with ADVERTISE_FAILED_DATA_TOO_LARGE
+            // (error code 1). This matters because UWB-interop UUIDs (Nordic UART,
+            // Qorvo NI) are full 128-bit values, unlike the base-UUID-derived FFF0
+            // which Android compresses to 2 bytes.
             val data = AdvertiseData.Builder()
-                .setIncludeDeviceName(true)
-                .addServiceUuid(ParcelUuid(SERVICE_UUID))
+                .setIncludeDeviceName(false)
+                .addServiceUuid(ParcelUuid(UUID.fromString(GattUuids.find{ it.name == GattName}?.discoveryServiceUUID?.uppercase())))
                 .build()
 
-            advertiser.startAdvertising(settings, data, advertiseCallback)
+            val scanResponse = AdvertiseData.Builder()
+                .setIncludeDeviceName(true)
+                .build()
+
+            advertiser.startAdvertising(settings, data, scanResponse, advertiseCallback)
             Log.d(TAG, "BLE advertising started")
         } catch (e: Exception) {
             Log.e(TAG, "Error starting BLE advertising: ${e.message}")
@@ -277,6 +308,7 @@ actual class BleManager(private val context: Context) {
 
     // ---- Public API: GATT Server ----
 
+    @RequiresPermission(BLUETOOTH_CONNECT)
     actual fun startGattServer(localConfig: UwbSessionConfig) {
         this.localConfig = localConfig
         if (!hasConnectPermission()) {
@@ -287,36 +319,38 @@ actual class BleManager(private val context: Context) {
         try {
             val server = bluetoothManager.openGattServer(context, gattServerCallback)
             gattServer = server
+            GattUuids.forEachIndexed { index, serviceEntry ->
+                // Build the UWB config service
+                val service = BluetoothGattService(
+                    UUID.fromString(serviceEntry.discoveryServiceUUID.uppercase()),
+                    if(index==0) BluetoothGattService.SERVICE_TYPE_PRIMARY else BluetoothGattService.SERVICE_TYPE_SECONDARY
+                )
 
-            // Build the UWB config service
-            val service = BluetoothGattService(
-                SERVICE_UUID,
-                BluetoothGattService.SERVICE_TYPE_PRIMARY
-            )
+                // Readable characteristic: our local config
+                val readChar = BluetoothGattCharacteristic(
+                    UUID.fromString(serviceEntry.readFromUUID.uppercase()),
+                    BluetoothGattCharacteristic.PROPERTY_READ or BluetoothGattCharacteristic.PROPERTY_NOTIFY,
+                    BluetoothGattCharacteristic.PERMISSION_READ
+                )
+                service.addCharacteristic(readChar)
 
-            // Readable characteristic: our local config
-            val readChar = BluetoothGattCharacteristic(
-                CONFIG_READ_UUID,
-                BluetoothGattCharacteristic.PROPERTY_READ,
-                BluetoothGattCharacteristic.PERMISSION_READ
-            )
-            service.addCharacteristic(readChar)
+                // Writable characteristic: peer writes their config here
+                val writeChar = BluetoothGattCharacteristic(
+                    UUID.fromString(serviceEntry.writeToUUID.uppercase()),
+                    BluetoothGattCharacteristic.PROPERTY_WRITE,
+                    BluetoothGattCharacteristic.PERMISSION_WRITE
+                )
+                service.addCharacteristic(writeChar)
 
-            // Writable characteristic: peer writes their config here
-            val writeChar = BluetoothGattCharacteristic(
-                CONFIG_WRITE_UUID,
-                BluetoothGattCharacteristic.PROPERTY_WRITE,
-                BluetoothGattCharacteristic.PERMISSION_WRITE
-            )
-            service.addCharacteristic(writeChar)
-
-            server.addService(service)
+                server.addService(service)
+            }
             Log.d(TAG, "GATT server started")
         } catch (e: Exception) {
             Log.e(TAG, "Error starting GATT server: ${e.message}")
         }
     }
 
+    @RequiresPermission(BLUETOOTH_CONNECT)
     actual fun stopGattServer() {
         try {
             gattServer?.close()
@@ -330,8 +364,9 @@ actual class BleManager(private val context: Context) {
 
     // ---- Public API: GATT Client (config exchange) ----
 
+    @RequiresPermission(BLUETOOTH_CONNECT)
     actual fun connectAndExchangeConfig(peerId: String, localConfig: UwbSessionConfig) {
-        val device = discoveredDevices[peerId]
+        val device = discoveredDevices[peerId]?.bleDevice
         if (device == null) {
             Log.e(TAG, "No BluetoothDevice cached for $peerId")
             return
@@ -340,9 +375,11 @@ actual class BleManager(private val context: Context) {
             Log.e(TAG, "Missing BLUETOOTH_CONNECT permission for GATT client")
             return
         }
+        val serviceEntry: ServiceEntry? = discoveredDevices[peerId]?.service ?: null
 
         try {
             device.connectGatt(context, false, object : BluetoothGattCallback() {
+                @RequiresPermission(BLUETOOTH_CONNECT)
                 override fun onConnectionStateChange(gatt: BluetoothGatt, status: Int, newState: Int) {
                     if (newState == BluetoothProfile.STATE_CONNECTED) {
                         Log.d(TAG, "GATT client: connected to $peerId, discovering services")
@@ -353,6 +390,7 @@ actual class BleManager(private val context: Context) {
                     }
                 }
 
+                @RequiresPermission(BLUETOOTH_CONNECT)
                 override fun onServicesDiscovered(gatt: BluetoothGatt, status: Int) {
                     if (status != BluetoothGatt.GATT_SUCCESS) {
                         Log.e(TAG, "GATT client: service discovery failed for $peerId")
@@ -360,7 +398,7 @@ actual class BleManager(private val context: Context) {
                         return
                     }
 
-                    val service = gatt.getService(SERVICE_UUID)
+                    val service = gatt.getService(UUID.fromString(serviceEntry?.discoveryServiceUUID?.uppercase()))
                     if (service == null) {
                         Log.e(TAG, "GATT client: UWB config service not found on $peerId")
                         gatt.close()
@@ -368,7 +406,7 @@ actual class BleManager(private val context: Context) {
                     }
 
                     // Step 1: Read peer's config
-                    val readChar = service.getCharacteristic(CONFIG_READ_UUID)
+                    val readChar = service.getCharacteristic(UUID.fromString(serviceEntry?.readFromUUID?.uppercase()))
                     if (readChar != null) {
                         gatt.readCharacteristic(readChar)
                     } else {
@@ -377,6 +415,7 @@ actual class BleManager(private val context: Context) {
                     }
                 }
 
+                @RequiresPermission(BLUETOOTH_CONNECT)
                 @Suppress("DEPRECATION")
                 override fun onCharacteristicRead(
                     gatt: BluetoothGatt,
@@ -388,8 +427,8 @@ actual class BleManager(private val context: Context) {
                         gatt.close()
                         return
                     }
-
-                    if (characteristic.uuid == CONFIG_READ_UUID) {
+                    val service = gatt.getService(UUID.fromString(serviceEntry?.discoveryServiceUUID?.uppercase()))
+                    if (characteristic.uuid == service.getCharacteristic(UUID.fromString(serviceEntry?.readFromUUID?.uppercase()))) {
                         val remoteConfigBytes = characteristic.value
                         val remoteConfig = remoteConfigBytes?.let { UwbSessionConfig.fromByteArray(it) }
 
@@ -401,8 +440,7 @@ actual class BleManager(private val context: Context) {
                         }
 
                         // Step 2: Write our config to peer
-                        val service = gatt.getService(SERVICE_UUID)
-                        val writeChar = service?.getCharacteristic(CONFIG_WRITE_UUID)
+                        val writeChar = service?.getCharacteristic(UUID.fromString(serviceEntry?.writeToUUID))
                         if (writeChar != null) {
                             writeChar.value = localConfig.toByteArray()
                             gatt.writeCharacteristic(writeChar)
@@ -412,6 +450,7 @@ actual class BleManager(private val context: Context) {
                     }
                 }
 
+                @RequiresPermission(BLUETOOTH_CONNECT)
                 @Suppress("DEPRECATION")
                 override fun onCharacteristicWrite(
                     gatt: BluetoothGatt,
@@ -432,6 +471,7 @@ actual class BleManager(private val context: Context) {
         }
     }
 
+    @RequiresPermission(BLUETOOTH_SCAN)
     actual fun cleanup() {
         stopScanning()
         stopAdvertising()

--- a/uwbmodule/src/androidMain/kotlin/BleManager.kt
+++ b/uwbmodule/src/androidMain/kotlin/BleManager.kt
@@ -26,10 +26,11 @@ import android.os.Build
 import android.os.ParcelUuid
 import android.util.Log
 import androidx.annotation.RequiresPermission
+import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import java.util.UUID
 
-var GattName = "QorvoNearbyFixed"
+var GattName = "us"
 actual class BleManager(private val context: Context) {
     private val TAG = "BleManager"
 
@@ -68,21 +69,23 @@ actual class BleManager(private val context: Context) {
             } else {
                 "Unknown Device"
             }
-
-            result.scanRecord?.serviceUuids?.forEach { uuid ->
-                GattUuids.forEach { serviceEntry ->
-                    if(serviceEntry.discoveryServiceUUID.uppercase() == uuid.toString().uppercase())
-                        if(service == null) {
-                            service = serviceEntry
-                        }
+            if(discoveredDevices[deviceAddress] == null) {
+                result.scanRecord?.serviceUuids?.forEach { uuid ->
+                    GattUuids.forEach { serviceEntry ->
+                        if (serviceEntry.discoveryServiceUUID.uppercase() == uuid.toString()
+                                .uppercase()
+                        )
+                            if (service == null) {
+                                service = serviceEntry
+                            }
+                    }
                 }
+                // Cache the BluetoothDevice for later GATT connection
+                discoveredDevices[deviceAddress] = accessoryDevice(device, service)
+
+                Log.d(TAG, "Found device: $deviceName ($deviceAddress)")
+                deviceDiscoveredCallback?.invoke(deviceAddress, deviceName)
             }
-            // Cache the BluetoothDevice for later GATT connection
-            discoveredDevices[deviceAddress] = accessoryDevice(device,service)
-
-            Log.d(TAG, "Found device: $deviceName ($deviceAddress)")
-            deviceDiscoveredCallback?.invoke(deviceAddress, deviceName)
-
         }
 
         override fun onScanFailed(errorCode: Int) {
@@ -106,12 +109,34 @@ actual class BleManager(private val context: Context) {
 
     private val gattServerCallback = object : BluetoothGattServerCallback() {
 
+       /* @RequiresPermission(BLUETOOTH_CONNECT)
+        fun onServiceAdded(status: Int, characteristic: BluetoothGattCharacteristic){
+            Log.d(TAG, "GATT server: service added")
+            addGattService(status+1)
+        }*/
+
         override fun onConnectionStateChange(device: BluetoothDevice, status: Int, newState: Int) {
             if (newState == BluetoothProfile.STATE_CONNECTED) {
                 Log.d(TAG, "GATT server: device connected: ${device.address}")
             } else if (newState == BluetoothProfile.STATE_DISCONNECTED) {
                 Log.d(TAG, "GATT server: device disconnected: ${device.address}")
             }
+        }
+
+        @RequiresPermission(BLUETOOTH_CONNECT)
+        override fun onServiceAdded(status: Int, service: BluetoothGattService?) {
+            super.onServiceAdded(status, service)
+            Log.d(TAG,"Service Added ${service?.uuid.toString()}, status=${status}")
+            // find the one just added
+            GattUuids.forEachIndexed { index, entry ->
+                if( service?.uuid.toString().equals(entry.discoveryServiceUUID, ignoreCase = true)   ){
+                    // if we aren't on the last
+                    if(index <GattUuids.lastIndex)
+                        // add the next one
+                        addGattService(index+1 )
+                }
+            }
+
         }
 
         @RequiresPermission(BLUETOOTH_CONNECT)
@@ -241,6 +266,7 @@ actual class BleManager(private val context: Context) {
 
     // ---- Public API: Advertising ----
 
+    @RequiresPermission(BLUETOOTH_CONNECT)
     actual fun advertise() {
         if (bluetoothAdapter == null || bluetoothAdapter?.isEnabled != true) {
             Log.e(TAG, "Bluetooth is not enabled or not supported")
@@ -281,7 +307,8 @@ actual class BleManager(private val context: Context) {
 
             advertiser.startAdvertising(settings, data, scanResponse, advertiseCallback)
             Log.d(TAG, "BLE advertising started")
-        } catch (e: Exception) {
+        }
+        catch (e:Exception){
             Log.e(TAG, "Error starting BLE advertising: ${e.message}")
         }
     }
@@ -318,33 +345,9 @@ actual class BleManager(private val context: Context) {
         }
 
         try {
-            val server = bluetoothManager.openGattServer(context, gattServerCallback)
+            val server= bluetoothManager.openGattServer(context, gattServerCallback)
             gattServer = server
-            GattUuids.forEachIndexed { index, serviceEntry ->
-                // Build the UWB config service
-                val service = BluetoothGattService(
-                    UUID.fromString(serviceEntry.discoveryServiceUUID.uppercase()),
-                    if(index==0) BluetoothGattService.SERVICE_TYPE_PRIMARY else BluetoothGattService.SERVICE_TYPE_SECONDARY
-                )
-
-                // Readable characteristic: our local config
-                val readChar = BluetoothGattCharacteristic(
-                    UUID.fromString(serviceEntry.readFromUUID.uppercase()),
-                    BluetoothGattCharacteristic.PROPERTY_READ or BluetoothGattCharacteristic.PROPERTY_NOTIFY,
-                    BluetoothGattCharacteristic.PERMISSION_READ
-                )
-                service.addCharacteristic(readChar)
-
-                // Writable characteristic: peer writes their config here
-                val writeChar = BluetoothGattCharacteristic(
-                    UUID.fromString(serviceEntry.writeToUUID.uppercase()),
-                    BluetoothGattCharacteristic.PROPERTY_WRITE,
-                    BluetoothGattCharacteristic.PERMISSION_WRITE
-                )
-                service.addCharacteristic(writeChar)
-
-                server.addService(service)
-            }
+            addGattService(0)
             Log.d(TAG, "GATT server started")
         } catch (e: Exception) {
             Log.e(TAG, "Error starting GATT server: ${e.message}")
@@ -364,6 +367,36 @@ actual class BleManager(private val context: Context) {
     }
 
     // ---- Public API: GATT Client (config exchange) ----
+    @RequiresPermission(BLUETOOTH_CONNECT)
+    fun addGattService(index:Int){
+
+            // Build the UWB config service
+            val service = BluetoothGattService(
+                UUID.fromString(GattUuids[index].discoveryServiceUUID.uppercase()),
+                //if(index==0)
+                BluetoothGattService.SERVICE_TYPE_PRIMARY
+                //else BluetoothGattService.SERVICE_TYPE_SECONDARY
+            )
+
+            // Readable characteristic: our local config
+            val readChar = BluetoothGattCharacteristic(
+                UUID.fromString(GattUuids[index].readFromUUID.uppercase()),
+                BluetoothGattCharacteristic.PROPERTY_READ or BluetoothGattCharacteristic.PROPERTY_NOTIFY,
+                BluetoothGattCharacteristic.PERMISSION_READ
+            )
+            service.addCharacteristic(readChar)
+
+            // Writable characteristic: peer writes their config here
+            val writeChar = BluetoothGattCharacteristic(
+                UUID.fromString(GattUuids[index].writeToUUID.uppercase()),
+                BluetoothGattCharacteristic.PROPERTY_WRITE,
+                BluetoothGattCharacteristic.PERMISSION_WRITE
+            )
+            service.addCharacteristic(writeChar)
+            Log.d(TAG,"adding service in serviceAdded callback")
+        gattServer?.addService(service)
+
+    }
 
     @RequiresPermission(BLUETOOTH_CONNECT)
     actual fun connectAndExchangeConfig(peerId: String, localConfig: UwbSessionConfig) {
@@ -397,6 +430,9 @@ actual class BleManager(private val context: Context) {
                         Log.e(TAG, "GATT client: service discovery failed for $peerId")
                         gatt.close()
                         return
+                    }
+                    gatt.services.forEach { service ->
+                        Log.d(TAG, "service name found = ${service.uuid.toString()}")
                     }
 
                     val service = gatt.getService(UUID.fromString(serviceEntry?.discoveryServiceUUID?.uppercase()))

--- a/uwbmodule/src/androidMain/kotlin/BleManager.kt
+++ b/uwbmodule/src/androidMain/kotlin/BleManager.kt
@@ -30,8 +30,10 @@ import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import java.util.UUID
 
-var GattName = "us"
-actual class BleManager(private val context: Context) {
+actual class BleManager(
+    private val context: Context,
+    private val config: BleDiscoveryConfig = BleDiscoveryConfig(),
+) {
     private val TAG = "BleManager"
 
     private data class  accessoryDevice (
@@ -71,7 +73,7 @@ actual class BleManager(private val context: Context) {
             }
             if(discoveredDevices[deviceAddress] == null) {
                 result.scanRecord?.serviceUuids?.forEach { uuid ->
-                    GattUuids.forEach { serviceEntry ->
+                    config.profiles.forEach { serviceEntry ->
                         if (serviceEntry.discoveryServiceUUID.uppercase() == uuid.toString()
                                 .uppercase()
                         )
@@ -127,11 +129,11 @@ actual class BleManager(private val context: Context) {
         override fun onServiceAdded(status: Int, service: BluetoothGattService?) {
             super.onServiceAdded(status, service)
             Log.d(TAG,"Service Added ${service?.uuid.toString()}, status=${status}")
-            // find the one just added
-            GattUuids.forEachIndexed { index, entry ->
+            // addService() is async — chain the next profile's service only after this one is added.
+            config.profiles.forEachIndexed { index, entry ->
                 if( service?.uuid.toString().equals(entry.discoveryServiceUUID, ignoreCase = true)   ){
                     // if we aren't on the last
-                    if(index <GattUuids.lastIndex)
+                    if(index < config.profiles.lastIndex)
                         // add the next one
                         addGattService(index+1 )
                 }
@@ -146,8 +148,12 @@ actual class BleManager(private val context: Context) {
             offset: Int,
             characteristic: BluetoothGattCharacteristic
         ) {
-            var discoveredDevice= discoveredDevices[device.address]
-            if (characteristic.uuid.toString() == discoveredDevice?.service?.readFromUUID?.uppercase()) {
+            // The connecting central isn't in discoveredDevices (that map is filled by scanning, not
+            // the server role), so match the characteristic against any hosted profile's read char.
+            val isReadChar = config.profiles.any {
+                it.readFromUUID.equals(characteristic.uuid.toString(), ignoreCase = true)
+            }
+            if (isReadChar) {
                 val configBytes = localConfig?.toByteArray() ?: ByteArray(0)
                 val responseBytes = if (offset < configBytes.size) {
                     configBytes.copyOfRange(offset, configBytes.size)
@@ -171,8 +177,10 @@ actual class BleManager(private val context: Context) {
             offset: Int,
             value: ByteArray?
         ) {
-            var discoveredDevice= discoveredDevices[device.address]
-            if (characteristic.uuid.toString() == discoveredDevice?.service?.writeToUUID?.uppercase() && value != null) {
+            val isWriteChar = config.profiles.any {
+                it.writeToUUID.equals(characteristic.uuid.toString(), ignoreCase = true)
+            }
+            if (isWriteChar && value != null) {
                 gattServer?.sendResponse(device, requestId, BluetoothGatt.GATT_SUCCESS, 0, null)
 
                 val remoteConfig = UwbSessionConfig.fromByteArray(value)
@@ -236,11 +244,11 @@ actual class BleManager(private val context: Context) {
             }
 
             val scanSettings = ScanSettings.Builder()
-                .setScanMode(ScanSettings.SCAN_MODE_LOW_LATENCY or ScanSettings.CALLBACK_TYPE_FIRST_MATCH)
+                .setScanMode(ScanSettings.SCAN_MODE_LOW_LATENCY)
                 .build()
 
             var filters: MutableList<ScanFilter> = mutableListOf()
-            GattUuids.forEach { serviceEntry ->
+            config.profiles.forEach { serviceEntry ->
                 val scanFilter = ScanFilter.Builder()
                     .setServiceUuid(ParcelUuid(UUID.fromString(serviceEntry.discoveryServiceUUID.uppercase())))
                     .build()
@@ -298,7 +306,7 @@ actual class BleManager(private val context: Context) {
             // which Android compresses to 2 bytes.
             val data = AdvertiseData.Builder()
                 .setIncludeDeviceName(false)
-                .addServiceUuid(ParcelUuid((UUID.fromString(GattUuids.find { it.name == GattName }?.discoveryServiceUUID?.uppercase()))))
+                .addServiceUuid(ParcelUuid((UUID.fromString(config.profiles.find { it.name == config.advertiseProfile }?.discoveryServiceUUID?.uppercase()))))
                 .build()
 
             val scanResponse = AdvertiseData.Builder()
@@ -370,25 +378,25 @@ actual class BleManager(private val context: Context) {
     @RequiresPermission(BLUETOOTH_CONNECT)
     fun addGattService(index:Int){
 
-            // Build the UWB config service
+            // Build the UWB config service. All profiles are PRIMARY so each is independently
+            // discoverable by a connecting client.
             val service = BluetoothGattService(
-                UUID.fromString(GattUuids[index].discoveryServiceUUID.uppercase()),
-                //if(index==0)
+                UUID.fromString(config.profiles[index].discoveryServiceUUID.uppercase()),
                 BluetoothGattService.SERVICE_TYPE_PRIMARY
-                //else BluetoothGattService.SERVICE_TYPE_SECONDARY
             )
 
-            // Readable characteristic: our local config
+            // Readable characteristic: our local config. (Read-only for now; the accessory-protocol
+            // tx-notify flow would also need a CCCD descriptor + notifyCharacteristicChanged — future work.)
             val readChar = BluetoothGattCharacteristic(
-                UUID.fromString(GattUuids[index].readFromUUID.uppercase()),
-                BluetoothGattCharacteristic.PROPERTY_READ or BluetoothGattCharacteristic.PROPERTY_NOTIFY,
+                UUID.fromString(config.profiles[index].readFromUUID.uppercase()),
+                BluetoothGattCharacteristic.PROPERTY_READ,
                 BluetoothGattCharacteristic.PERMISSION_READ
             )
             service.addCharacteristic(readChar)
 
             // Writable characteristic: peer writes their config here
             val writeChar = BluetoothGattCharacteristic(
-                UUID.fromString(GattUuids[index].writeToUUID.uppercase()),
+                UUID.fromString(config.profiles[index].writeToUUID.uppercase()),
                 BluetoothGattCharacteristic.PROPERTY_WRITE,
                 BluetoothGattCharacteristic.PERMISSION_WRITE
             )
@@ -465,7 +473,7 @@ actual class BleManager(private val context: Context) {
                         return
                     }
                     val service = gatt.getService(UUID.fromString(serviceEntry?.discoveryServiceUUID?.uppercase()))
-                    if (characteristic.uuid == service.getCharacteristic(UUID.fromString(serviceEntry?.readFromUUID?.uppercase()))) {
+                    if (characteristic.uuid == UUID.fromString(serviceEntry?.readFromUUID?.uppercase())) {
                         val remoteConfigBytes = characteristic.value
                         val remoteConfig = remoteConfigBytes?.let { UwbSessionConfig.fromByteArray(it) }
 
@@ -477,7 +485,7 @@ actual class BleManager(private val context: Context) {
                         }
 
                         // Step 2: Write our config to peer
-                        val writeChar = service?.getCharacteristic(UUID.fromString(serviceEntry?.writeToUUID))
+                        val writeChar = service?.getCharacteristic(UUID.fromString(serviceEntry?.writeToUUID?.uppercase()))
                         if (writeChar != null) {
                             writeChar.value = localConfig.toByteArray()
                             gatt.writeCharacteristic(writeChar)

--- a/uwbmodule/src/androidMain/kotlin/ManagerFactory.android.kt
+++ b/uwbmodule/src/androidMain/kotlin/ManagerFactory.android.kt
@@ -9,7 +9,7 @@ actual class ManagerFactory(private val context: Context) {
         return MultiplatformUwbManager(uwbManager)
     }
 
-    actual fun createBleManager(): BleManager {
-        return BleManager(context)
+    actual fun createBleManager(config: BleDiscoveryConfig): BleManager {
+        return BleManager(context, config)
     }
 }

--- a/uwbmodule/src/commonMain/kotlin/GattUuids.kt
+++ b/uwbmodule/src/commonMain/kotlin/GattUuids.kt
@@ -10,16 +10,28 @@ package com.dustedrob.uwb
  * 4. Initiator writes its own [UwbSessionConfig] to [UWB_CONFIG_WRITE_CHAR_UUID].
  * 5. Both sides now have each other's config → start UWB ranging.
  */
-object GattUuids {
+
+data class ServiceEntry (
+    val name: String,
+    val discoveryServiceUUID: String,
+    val readFromUUID: String,
+    val writeToUUID: String
+)
     /** Primary GATT service for UWB config exchange. */
-    const val UWB_CONFIG_SERVICE_UUID = "0000FFF0-0000-1000-8000-00805F9B34FB"
+    const val UWB_CONFIG_SERVICE_UUID =  "0000FFF0-0000-1000-8000-00805F9B34FB"
 
     /** Readable characteristic: the GATT server's local UWB config (serialized [UwbSessionConfig]). */
     const val UWB_CONFIG_CHAR_UUID = "0000FFF1-0000-1000-8000-00805F9B34FB"
 
     /** Writable characteristic: the GATT client writes its UWB config here. */
     const val UWB_CONFIG_WRITE_CHAR_UUID = "0000FFF2-0000-1000-8000-00805F9B34FB"
-
-    /** BLE service UUID used for advertising/discovery (same as before, for scan filters). */
     const val UWB_DISCOVERY_SERVICE_UUID = "0000FFF0-0000-1000-8000-00805F9B34FB"
-}
+
+var  GattUuids = arrayOf<ServiceEntry>(
+
+    ServiceEntry("us", UWB_CONFIG_SERVICE_UUID, UWB_CONFIG_CHAR_UUID,UWB_CONFIG_WRITE_CHAR_UUID ),
+    ServiceEntry("QorvoNearbyFixed", "2E938FD0-6A61-11ED-A1EB-0242AC120002", "2E939AF2-6A61-11ED-A1EB-0242AC120002" ,"2E93998A-6A61-11ED-A1EB-0242AC120002" ),
+    ServiceEntry("NearbyFixed", "6E400001-B5A3-F393-E0A9-E50E24DCCA9E", "6E400003-B5A3-F393-E0A9-E50E24DCCA9E", "6E400002-B5A3-F393-E0A9-E50E24DCCA9E" ),
+
+    /** BLE service UUID used for advertising/discovery (same as before, for scan filters). */   
+)

--- a/uwbmodule/src/commonMain/kotlin/GattUuids.kt
+++ b/uwbmodule/src/commonMain/kotlin/GattUuids.kt
@@ -1,37 +1,83 @@
 package com.dustedrob.uwb
 
 /**
- * BLE GATT UUIDs for the UWB configuration exchange protocol.
+ * BLE GATT service profiles for the UWB configuration exchange.
  *
- * Protocol flow:
- * 1. Responder starts a GATT server and advertises [UWB_CONFIG_SERVICE_UUID].
- * 2. Initiator discovers responder via BLE scan, connects to GATT server.
- * 3. Initiator reads [UWB_CONFIG_CHAR_UUID] to get responder's [UwbSessionConfig].
- * 4. Initiator writes its own [UwbSessionConfig] to [UWB_CONFIG_WRITE_CHAR_UUID].
+ * A [ServiceEntry] describes one BLE "profile": the service that is advertised/scanned for, plus the
+ * two characteristics used to exchange a serialized [UwbSessionConfig].
+ *
+ * Protocol flow (per matched profile):
+ * 1. Responder starts a GATT server and advertises [ServiceEntry.discoveryServiceUUID].
+ * 2. Initiator discovers the responder via BLE scan, connects to the GATT server.
+ * 3. Initiator reads [ServiceEntry.readFromUUID] to get the responder's [UwbSessionConfig].
+ * 4. Initiator writes its own [UwbSessionConfig] to [ServiceEntry.writeToUUID].
  * 5. Both sides now have each other's config → start UWB ranging.
+ *
+ * The set of profiles and the locally advertised identity are supplied by the implementing app via
+ * [BleDiscoveryConfig]; the library only ships vendor-free defaults.
  */
-
-data class ServiceEntry (
+data class ServiceEntry(
+    /** App-facing label used to select which profile this device advertises (see [BleDiscoveryConfig.advertiseProfile]). */
     val name: String,
+    /** Service UUID advertised and scanned for. */
     val discoveryServiceUUID: String,
+    /** Characteristic the client reads to obtain the peer's config (the peer's "tx"). */
     val readFromUUID: String,
-    val writeToUUID: String
+    /** Characteristic the client writes its own config to (the peer's "rx"). */
+    val writeToUUID: String,
 )
-    /** Primary GATT service for UWB config exchange. */
-    const val UWB_CONFIG_SERVICE_UUID =  "0000FFF0-0000-1000-8000-00805F9B34FB"
 
-    /** Readable characteristic: the GATT server's local UWB config (serialized [UwbSessionConfig]). */
-    const val UWB_CONFIG_CHAR_UUID = "0000FFF1-0000-1000-8000-00805F9B34FB"
+/** This project's own (vendor-neutral) GATT service for UWB config exchange. */
+const val UWB_CONFIG_SERVICE_UUID = "0000FFF0-0000-1000-8000-00805F9B34FB"
 
-    /** Writable characteristic: the GATT client writes its UWB config here. */
-    const val UWB_CONFIG_WRITE_CHAR_UUID = "0000FFF2-0000-1000-8000-00805F9B34FB"
-    const val UWB_DISCOVERY_SERVICE_UUID = "0000FFF0-0000-1000-8000-00805F9B34FB"
+/** Readable characteristic: the GATT server's local UWB config (serialized [UwbSessionConfig]). */
+const val UWB_CONFIG_CHAR_UUID = "0000FFF1-0000-1000-8000-00805F9B34FB"
 
-var  GattUuids = arrayOf<ServiceEntry>(
+/** Writable characteristic: the GATT client writes its UWB config here. */
+const val UWB_CONFIG_WRITE_CHAR_UUID = "0000FFF2-0000-1000-8000-00805F9B34FB"
 
-    ServiceEntry("us", UWB_CONFIG_SERVICE_UUID, UWB_CONFIG_CHAR_UUID,UWB_CONFIG_WRITE_CHAR_UUID ),
-    ServiceEntry("QorvoNearbyFixed", "2E938FD0-6A61-11ED-A1EB-0242AC120002", "2E939AF2-6A61-11ED-A1EB-0242AC120002" ,"2E93998A-6A61-11ED-A1EB-0242AC120002" ),
-    ServiceEntry("NearbyFixed", "6E400001-B5A3-F393-E0A9-E50E24DCCA9E", "6E400003-B5A3-F393-E0A9-E50E24DCCA9E", "6E400002-B5A3-F393-E0A9-E50E24DCCA9E" ),
+/** The library's own profile — the default identity a device advertises and exchanges config over. */
+val LOCAL_PROFILE = ServiceEntry(
+    name = "local",
+    discoveryServiceUUID = UWB_CONFIG_SERVICE_UUID,
+    readFromUUID = UWB_CONFIG_CHAR_UUID,
+    writeToUUID = UWB_CONFIG_WRITE_CHAR_UUID,
+)
 
-    /** BLE service UUID used for advertising/discovery (same as before, for scan filters). */   
+/**
+ * Opt-in profile for Qorvo Nearby-Interaction accessories. Not included in [DEFAULT_PROFILES] — add it
+ * explicitly via [BleDiscoveryConfig] if the app needs to talk to Qorvo NI hardware. The phone writes
+ * to the accessory's rx ([writeToUUID]) and reads/notifies from its tx ([readFromUUID]).
+ */
+val QORVO_NEARBY_PROFILE = ServiceEntry(
+    name = "QorvoNearbyFixed",
+    discoveryServiceUUID = "2E938FD0-6A61-11ED-A1EB-0242AC120002",
+    readFromUUID = "2E939AF2-6A61-11ED-A1EB-0242AC120002",
+    writeToUUID = "2E93998A-6A61-11ED-A1EB-0242AC120002",
+)
+
+/**
+ * Opt-in profile for the Nordic UART Service — Apple's common Nearby-Interaction accessory transport.
+ * Not included in [DEFAULT_PROFILES]; add it explicitly when targeting NUS-based accessories.
+ */
+val NORDIC_NEARBY_PROFILE = ServiceEntry(
+    name = "NearbyFixed",
+    discoveryServiceUUID = "6E400001-B5A3-F393-E0A9-E50E24DCCA9E",
+    readFromUUID = "6E400003-B5A3-F393-E0A9-E50E24DCCA9E",
+    writeToUUID = "6E400002-B5A3-F393-E0A9-E50E24DCCA9E",
+)
+
+/** Vendor-free default: only the library's own [LOCAL_PROFILE]. Apps add vendor profiles explicitly. */
+val DEFAULT_PROFILES = listOf(LOCAL_PROFILE)
+
+/**
+ * App-owned configuration for BLE discovery and config exchange.
+ *
+ * @property profiles the service profiles to scan for and host on the local GATT server.
+ * @property advertiseProfile the [ServiceEntry.name] of the profile this device advertises as its own
+ *   identity. Must match one of [profiles].
+ */
+data class BleDiscoveryConfig(
+    val profiles: List<ServiceEntry> = DEFAULT_PROFILES,
+    val advertiseProfile: String = DEFAULT_PROFILES.first().name,
 )

--- a/uwbmodule/src/commonMain/kotlin/ManagerFactory.kt
+++ b/uwbmodule/src/commonMain/kotlin/ManagerFactory.kt
@@ -11,6 +11,12 @@ expect class ManagerFactory {
     /** Create a platform-specific [MultiplatformUwbManager] for UWB ranging. */
     fun createUwbManager(): MultiplatformUwbManager
 
-    /** Create a platform-specific [BleManager] for BLE discovery and GATT exchange. */
-    fun createBleManager(): BleManager
+    /**
+     * Create a platform-specific [BleManager] for BLE discovery and GATT exchange.
+     *
+     * @param config the profiles to scan/serve and the locally advertised identity. Defaults to the
+     *   library's vendor-free [BleDiscoveryConfig]; pass a custom one to add vendor profiles
+     *   (e.g. [QORVO_NEARBY_PROFILE]) or change which profile this device advertises.
+     */
+    fun createBleManager(config: BleDiscoveryConfig = BleDiscoveryConfig()): BleManager
 }

--- a/uwbmodule/src/commonMain/kotlin/NearbyDevice.kt
+++ b/uwbmodule/src/commonMain/kotlin/NearbyDevice.kt
@@ -33,5 +33,5 @@ data class NearbyDevice(
     val state: DeviceState = DeviceState.Discovered,
     val errorMessage: String? = null,
     val sessionId: Int? = null,
-    val channel: Int? = null
+    val channel: Int? = null,
 )

--- a/uwbmodule/src/iosMain/kotlin/BleManager.kt
+++ b/uwbmodule/src/iosMain/kotlin/BleManager.kt
@@ -5,7 +5,7 @@ import platform.CoreBluetooth.*
 import platform.Foundation.*
 import platform.darwin.NSObject
 
-private val GattName = "QorvoNearbyFixed"
+private val GattName = "us"
 @OptIn(ExperimentalForeignApi::class)
 actual class BleManager {
 
@@ -32,6 +32,30 @@ actual class BleManager {
     // Deferred operations waiting for poweredOn
     private var scanWhenReady = false
     private var advertiseWhenReady = false
+
+    fun addGattService(index: Int){
+
+        val readChar = CBMutableCharacteristic(
+            type = CBUUID.UUIDWithString(GattUuids[index].readFromUUID),
+            properties = CBCharacteristicPropertyRead or CBCharacteristicPropertyNotify,
+            value = null, // Dynamic value — served via delegate
+            permissions = CBAttributePermissionsReadable
+        )
+        readCharacteristic = readChar
+
+        val writeChar = CBMutableCharacteristic(
+            type = CBUUID.UUIDWithString(GattUuids[index].readFromUUID),
+            properties = CBCharacteristicPropertyWrite or CBCharacteristicPropertyWriteWithoutResponse,
+            value = null,
+            permissions = CBAttributePermissionsWriteable
+        )
+
+        val service = CBMutableService(CBUUID.UUIDWithString(GattUuids[index].discoveryServiceUUID ?: ""), primary = true)
+        service.setCharacteristics(listOf(readChar, writeChar))
+
+        peripheralManager?.addService(service)
+        NSLog("BleManager: GATT service added")
+    }
 
     // ---- Central (scanner/client) delegate ----
 
@@ -69,13 +93,17 @@ actual class BleManager {
                 val serviceUuids =
                     advertisementData[CBAdvertisementDataServiceUUIDsKey] as? List<CBUUID> ?: return
                 serviceUuids.forEach { id ->
-                    NSLog("discovered device service UUID= @", id.UUIDString)
+                    NSLog("discovered device service UUID= ${id.UUIDString}")
                 }
+
                 // Loop through the advertised service UUIDs to find a match
                 GattUuids.forEach { set ->
+                    //NSLog("BleManager: serviceUUID=${set.discoveryServiceUUID} - setid = ${set.discoveryServiceUUID.slice(IntRange(4,7))}")
                     val hasTargetService =
-                        serviceUuids.any { it.UUIDString == set.discoveryServiceUUID }
+                        serviceUuids.any { it.UUIDString() == set.discoveryServiceUUID || "0000"+it.UUIDString ==  set.discoveryServiceUUID.slice(IntRange(0,7))
+                    }
                     if (hasTargetService) {
+                        NSLog("BleManager: found set=${set.discoveryServiceUUID}")
                         service = set
                     }
                 }
@@ -100,9 +128,9 @@ actual class BleManager {
             val services: MutableList<CBUUID> = mutableListOf()
             NSLog("BleManager: discovering services from")
             NSLog( discoveredPeripherals[deviceId]?.service?.discoveryServiceUUID?:"")
-            services.add(CBUUID.UUIDWithString(discoveredPeripherals[deviceId]?.service?.discoveryServiceUUID?:""))
+            services.add(CBUUID.UUIDWithString((discoveredPeripherals[deviceId]?.service?.discoveryServiceUUID?:"").uppercase()))
 
-            didConnectPeripheral.discoverServices(services)
+            didConnectPeripheral.discoverServices(null) //services)
         }
 
         // Note: didFailToConnect and didDisconnect omitted to avoid ObjC selector conflicts
@@ -119,8 +147,10 @@ actual class BleManager {
                 return
             }
             val discoveredDevice = discoveredPeripherals[peripheral.identifier.UUIDString]
-            val service = peripheral.services?.firstOrNull {
-                (it as? CBService)?.UUID == discoveredDevice?.service?.discoveryServiceUUID?.let { theString -> CBUUID.UUIDWithString(theString  ) }
+            NSLog("BleManager: device service =${peripheral.services} and service on scan discover was ${discoveredDevice?.service?.discoveryServiceUUID}")
+            val service= peripheral.services?.firstOrNull {
+                (it as? CBService)?.UUID.toString() == discoveredDevice?.service?.discoveryServiceUUID?.uppercase() ||
+                "0000"+(it as? CBService)?.UUID.toString() == discoveredDevice?.service?.discoveryServiceUUID?.slice(IntRange(0,7))
             } as? CBService
 
             if (service == null) {
@@ -149,6 +179,7 @@ actual class BleManager {
             val discovererDevice = discoveredPeripherals[peripheral.identifier.UUIDString]
             // Step 1: Read the peer's config
             var readChar:  CBCharacteristic? = null
+
             didDiscoverCharacteristicsForService.characteristics?.forEach { c ->
                 NSLog("discovered char="+c.toString())
                 (c as? CBCharacteristic)?.let { char ->
@@ -156,9 +187,13 @@ actual class BleManager {
                             CBUUID.UUIDWithString(
                                 it.uppercase()
                             )
-                        })
-                        readChar = char as CBCharacteristic?
-                    NSLog("characteristic found = ${readChar?.UUID?.UUIDString}")
+                        }
+                        ){
+                        if(readChar==null)
+                            readChar = char as CBCharacteristic?
+                    }
+
+                    NSLog("characteristic found = ${c.UUID.UUIDString}")
                 }
             }
 
@@ -177,12 +212,13 @@ actual class BleManager {
             error: NSError?
         ) {
             if (error != null) {
-                NSLog("BleManager: Characteristic update error: ${error.localizedDescription}")
+                NSLog("BleManager: Characteristic update error: ${error.localizedDescription} ${didUpdateValueForCharacteristic.UUID}")
                 centralManager?.cancelPeripheralConnection(peripheral)
                 return
             }
             val peerId = peripheral.identifier.UUIDString
             val discovererDevice = discoveredPeripherals[peerId]
+            NSLog("update characteristic = ${didUpdateValueForCharacteristic.UUID}")
             if (didUpdateValueForCharacteristic.UUID == discovererDevice?.service?.readFromUUID?.let { CBUUID.UUIDWithString(it) }){
 
                 val data = didUpdateValueForCharacteristic.value
@@ -227,6 +263,7 @@ actual class BleManager {
 
     private val peripheralManagerDelegate = object : NSObject(), CBPeripheralManagerDelegateProtocol {
 
+
         override fun peripheralManagerDidUpdateState(peripheral: CBPeripheralManager) {
             if (peripheral.state == CBManagerStatePoweredOn) {
                 NSLog("BleManager: Peripheral manager powered on")
@@ -259,6 +296,16 @@ actual class BleManager {
                 NSLog("BleManager: Failed to add service: ${error.localizedDescription}")
             } else {
                 NSLog("BleManager: GATT service added")
+                GattUuids.forEachIndexed { index, service ->
+                   NSLog("checking ${didAddService.UUID.UUIDString} against ${service.discoveryServiceUUID}")
+                    if( didAddService.UUID.UUIDString.equals(service.discoveryServiceUUID, ignoreCase = true)   ){
+                        // if we aren't on the last
+                        NSLog("BleManager: checking service index ${service.discoveryServiceUUID}")
+                        if(index <GattUuids.lastIndex)
+                        // add the next one
+                            addGattService(index+1 )
+                    }
+                }
             }
         }
 
@@ -320,6 +367,7 @@ actual class BleManager {
 
     // ---- Public API: Scanning ----
 
+
     actual fun startScanning() {
         val central = centralManager ?: CBCentralManager(centralDelegate, null).also {
             centralManager = it
@@ -361,9 +409,11 @@ actual class BleManager {
 
     private fun startAdvertisingInternal() {
         val services: MutableList<CBUUID> = mutableListOf()
-        GattUuids.forEach { set ->
+       /* GattUuids.forEach { set ->
             services.add(CBUUID.UUIDWithString(set.discoveryServiceUUID))
-        }
+        }*/
+        val uidstring = GattUuids.find { it.name == GattName }?.discoveryServiceUUID ?: ""
+        services.add(CBUUID.UUIDWithString(uidstring))
         val advertisementData = mapOf<Any?, Any?>(
             CBAdvertisementDataServiceUUIDsKey to services,
             CBAdvertisementDataLocalNameKey to "UWB Device"
@@ -394,29 +444,10 @@ actual class BleManager {
         if (peripheralManager == null) {
             peripheralManager = CBPeripheralManager(peripheralManagerDelegate, null)
         }
+        GattUuids.forEachIndexed { index, entry ->
+            addGattService(index)
+        }
 
-        // Build the GATT service
-        NSLog(("read char= ${GattUuids.find { it.name == GattName }?.readFromUUID ?: ""}"))
-        val readChar = CBMutableCharacteristic(
-            type = CBUUID.UUIDWithString(GattUuids.find { it.name == GattName }?.readFromUUID ?: ""),
-            properties = CBCharacteristicPropertyRead or CBCharacteristicPropertyNotify,
-            value = null, // Dynamic value — served via delegate
-            permissions = CBAttributePermissionsReadable
-        )
-        readCharacteristic = readChar
-
-        val writeChar = CBMutableCharacteristic(
-            type = CBUUID.UUIDWithString(GattUuids.find { it.name == GattName }?.writeToUUID ?: ""),
-            properties = CBCharacteristicPropertyWrite or CBCharacteristicPropertyWriteWithoutResponse,
-            value = null,
-            permissions = CBAttributePermissionsWriteable
-        )
-
-        val service = CBMutableService(CBUUID.UUIDWithString(GattUuids.find { it.name == GattName }?.discoveryServiceUUID ?: ""), primary = true)
-        service.setCharacteristics(listOf(readChar, writeChar))
-
-        peripheralManager?.addService(service)
-        NSLog("BleManager: GATT server started")
     }
 
     actual fun stopGattServer() {
@@ -429,6 +460,7 @@ actual class BleManager {
     // ---- Public API: GATT Client (config exchange) ----
 
     actual fun connectAndExchangeConfig(peerId: String, localConfig: UwbSessionConfig) {
+        NSLog("BleManager: in connect and config")
         val peripheral = discoveredPeripherals[peerId]?.bleDevice
         if (peripheral == null) {
             NSLog("BleManager: No cached peripheral for $peerId")
@@ -436,7 +468,7 @@ actual class BleManager {
         }
 
         pendingConfigs[peerId] = localConfig
-
+        NSLog("BleManager: starting connect")
         centralManager?.connectPeripheral(peripheral, null)
         NSLog("BleManager: Connecting to $peerId for config exchange")
     }
@@ -454,3 +486,4 @@ actual class BleManager {
         NSLog("BleManager: Cleanup completed")
     }
 }
+

--- a/uwbmodule/src/iosMain/kotlin/BleManager.kt
+++ b/uwbmodule/src/iosMain/kotlin/BleManager.kt
@@ -5,12 +5,9 @@ import platform.CoreBluetooth.*
 import platform.Foundation.*
 import platform.darwin.NSObject
 
+private val GattName = "QorvoNearbyFixed"
 @OptIn(ExperimentalForeignApi::class)
 actual class BleManager {
-
-    private val serviceUUID = CBUUID.UUIDWithString(GattUuids.UWB_DISCOVERY_SERVICE_UUID)
-    private val configReadUUID = CBUUID.UUIDWithString(GattUuids.UWB_CONFIG_CHAR_UUID)
-    private val configWriteUUID = CBUUID.UUIDWithString(GattUuids.UWB_CONFIG_WRITE_CHAR_UUID)
 
     private var centralManager: CBCentralManager? = null
     private var peripheralManager: CBPeripheralManager? = null
@@ -23,7 +20,11 @@ actual class BleManager {
     private var readCharacteristic: CBMutableCharacteristic? = null
 
     // Track discovered peripherals for GATT client connections
-    private val discoveredPeripherals = mutableMapOf<String, CBPeripheral>()
+    private data class  accessoryDevice (
+        val bleDevice: CBPeripheral? = null,
+        val service: ServiceEntry?=null
+    )
+    private val discoveredPeripherals = mutableMapOf<String, accessoryDevice>()
 
     // Pending config exchanges, keyed by peripheral UUID
     private val pendingConfigs = mutableMapOf<String, UwbSessionConfig>()
@@ -41,7 +42,11 @@ actual class BleManager {
                 NSLog("BleManager: Central powered on")
                 if (scanWhenReady) {
                     scanWhenReady = false
-                    central.scanForPeripheralsWithServices(listOf(serviceUUID), null)
+                    var serviceList: MutableList<CBUUID> = mutableListOf()
+                    GattUuids.forEach { set ->
+                        serviceList.add(CBUUID.UUIDWithString(set.discoveryServiceUUID))
+                    }
+                    central.scanForPeripheralsWithServices(serviceList, null)
                     NSLog("BleManager: Deferred scan started")
                 }
             } else {
@@ -56,13 +61,32 @@ actual class BleManager {
             RSSI: NSNumber
         ) {
             val deviceId = didDiscoverPeripheral.identifier.UUIDString
-            val deviceName = didDiscoverPeripheral.name ?: "Unknown Device"
+            if( discoveredPeripherals[deviceId] == null) {
+                val deviceName = didDiscoverPeripheral.name ?: "Unknown Device"
 
-            // Cache peripheral (must keep strong reference for connection)
-            discoveredPeripherals[deviceId] = didDiscoverPeripheral
+                var service: ServiceEntry? = null
+                // Extract advertised services from the advertisement data map
+                val serviceUuids =
+                    advertisementData[CBAdvertisementDataServiceUUIDsKey] as? List<CBUUID> ?: return
+                serviceUuids.forEach { id ->
+                    NSLog("discovered device service UUID= @", id.UUIDString)
+                }
+                // Loop through the advertised service UUIDs to find a match
+                GattUuids.forEach { set ->
+                    val hasTargetService =
+                        serviceUuids.any { it.UUIDString == set.discoveryServiceUUID }
+                    if (hasTargetService) {
+                        service = set
+                    }
+                }
 
-            NSLog("BleManager: Discovered $deviceName ($deviceId)")
-            deviceDiscoveredCallback?.invoke(deviceId, deviceName)
+                // Cache peripheral (must keep strong reference for connection)
+                // need to relate the service (and characteristics) found in response to ble scan services
+                discoveredPeripherals[deviceId] = accessoryDevice(didDiscoverPeripheral, service)
+
+                NSLog("BleManager: Discovered $deviceName ($deviceId)")
+                deviceDiscoveredCallback?.invoke(deviceId, deviceName)
+            }
         }
 
         override fun centralManager(
@@ -70,9 +94,15 @@ actual class BleManager {
             didConnectPeripheral: CBPeripheral
         ) {
             val deviceId = didConnectPeripheral.identifier.UUIDString
+            val device = discoveredPeripherals[deviceId]
             NSLog("BleManager: Connected to $deviceId, discovering services")
             didConnectPeripheral.delegate = peripheralClientDelegate
-            didConnectPeripheral.discoverServices(listOf(serviceUUID))
+            val services: MutableList<CBUUID> = mutableListOf()
+            NSLog("BleManager: discovering services from")
+            NSLog( discoveredPeripherals[deviceId]?.service?.discoveryServiceUUID?:"")
+            services.add(CBUUID.UUIDWithString(discoveredPeripherals[deviceId]?.service?.discoveryServiceUUID?:""))
+
+            didConnectPeripheral.discoverServices(services)
         }
 
         // Note: didFailToConnect and didDisconnect omitted to avoid ObjC selector conflicts
@@ -88,9 +118,9 @@ actual class BleManager {
                 centralManager?.cancelPeripheralConnection(peripheral)
                 return
             }
-
+            val discoveredDevice = discoveredPeripherals[peripheral.identifier.UUIDString]
             val service = peripheral.services?.firstOrNull {
-                (it as? CBService)?.UUID == serviceUUID
+                (it as? CBService)?.UUID == discoveredDevice?.service?.discoveryServiceUUID?.let { theString -> CBUUID.UUIDWithString(theString  ) }
             } as? CBService
 
             if (service == null) {
@@ -98,8 +128,12 @@ actual class BleManager {
                 centralManager?.cancelPeripheralConnection(peripheral)
                 return
             }
-
-            peripheral.discoverCharacteristics(listOf(configReadUUID, configWriteUUID), service)
+            NSLog(("discovering characteristics"))
+            peripheral.discoverCharacteristics( null, //listOf(
+                   // discoveredDevice?.service?.readFromUUID?.let {theString -> CBUUID.UUIDWithString(theString)},
+                   // discoveredDevice?.service?.writeToUUID?.let { theString -> CBUUID.UUIDWithString(theString)}
+            //),
+             service)
         }
 
         override fun peripheral(
@@ -112,11 +146,21 @@ actual class BleManager {
                 centralManager?.cancelPeripheralConnection(peripheral)
                 return
             }
-
+            val discovererDevice = discoveredPeripherals[peripheral.identifier.UUIDString]
             // Step 1: Read the peer's config
-            val readChar = didDiscoverCharacteristicsForService.characteristics?.firstOrNull {
-                (it as? CBCharacteristic)?.UUID == configReadUUID
-            } as? CBCharacteristic
+            var readChar:  CBCharacteristic? = null
+            didDiscoverCharacteristicsForService.characteristics?.forEach { c ->
+                NSLog("discovered char="+c.toString())
+                (c as? CBCharacteristic)?.let { char ->
+                    if (char.UUID == discovererDevice?.service?.readFromUUID?.let {
+                            CBUUID.UUIDWithString(
+                                it.uppercase()
+                            )
+                        })
+                        readChar = char as CBCharacteristic?
+                    NSLog("characteristic found = ${readChar?.UUID?.UUIDString}")
+                }
+            }
 
             if (readChar != null) {
                 peripheral.readValueForCharacteristic(readChar)
@@ -126,7 +170,7 @@ actual class BleManager {
             }
         }
 
-
+        // in response to notify
         override fun peripheral(
             peripheral: CBPeripheral,
             didUpdateValueForCharacteristic: CBCharacteristic,
@@ -137,9 +181,10 @@ actual class BleManager {
                 centralManager?.cancelPeripheralConnection(peripheral)
                 return
             }
+            val peerId = peripheral.identifier.UUIDString
+            val discovererDevice = discoveredPeripherals[peerId]
+            if (didUpdateValueForCharacteristic.UUID == discovererDevice?.service?.readFromUUID?.let { CBUUID.UUIDWithString(it) }){
 
-            if (didUpdateValueForCharacteristic.UUID == configReadUUID) {
-                val peerId = peripheral.identifier.UUIDString
                 val data = didUpdateValueForCharacteristic.value
                 if (data != null) {
                     val remoteConfig = UwbSessionConfig.fromByteArray(data.toByteArray())
@@ -156,11 +201,11 @@ actual class BleManager {
                 val localCfg = pendingConfigs[peerId]
                 if (localCfg != null) {
                     val service = peripheral.services?.firstOrNull {
-                        (it as? CBService)?.UUID == serviceUUID
+                        (it as? CBService)?.UUID == discovererDevice.service.discoveryServiceUUID?.let { CBUUID.UUIDWithString(it) }
                     } as? CBService
 
                     val writeChar = service?.characteristics?.firstOrNull {
-                        (it as? CBCharacteristic)?.UUID == configWriteUUID
+                        (it as? CBCharacteristic)?.UUID == discovererDevice.service.writeToUUID?.let { CBUUID.UUIDWithString(it) }
                     } as? CBCharacteristic
 
                     if (writeChar != null) {
@@ -221,7 +266,11 @@ actual class BleManager {
             peripheral: CBPeripheralManager,
             didReceiveReadRequest: CBATTRequest
         ) {
-            if (didReceiveReadRequest.characteristic.UUID == configReadUUID) {
+        
+            val peerId =  didReceiveReadRequest.central.identifier.UUIDString()
+            val discovererDevice = discoveredPeripherals[peerId]
+            if (didReceiveReadRequest.characteristic.UUID == discovererDevice?.service?.readFromUUID?.let { CBUUID.UUIDWithString(it) }) {
+            
                 val configBytes = localConfig?.toByteArray() ?: ByteArray(0)
                 val offset = didReceiveReadRequest.offset.toInt()
                 if (offset < configBytes.size) {
@@ -242,8 +291,14 @@ actual class BleManager {
             peripheral: CBPeripheralManager,
             didReceiveWriteRequests: List<*>
         ) {
+
             didReceiveWriteRequests.forEach { request ->
-                if (request is CBATTRequest && request.characteristic.UUID == configWriteUUID) {
+
+                if (request is CBATTRequest) {
+                  val r:CBATTRequest =request as CBATTRequest
+                  val peerId =  r.central.identifier.UUIDString()
+                  val discovererDevice = discoveredPeripherals[peerId]
+                  if( request.characteristic.UUID == discovererDevice?.service?.writeToUUID?.let { CBUUID.UUIDWithString(it) }) {
                     val data = request.value
                     if (data != null) {
                         val remoteConfig = UwbSessionConfig.fromByteArray(data.toByteArray())
@@ -257,8 +312,10 @@ actual class BleManager {
                     }
                     peripheral.respondToRequest(request, CBATTErrorSuccess)
                 }
+                }
             }
         }
+
     }
 
     // ---- Public API: Scanning ----
@@ -269,7 +326,14 @@ actual class BleManager {
         }
 
         if (central.state == CBManagerStatePoweredOn) {
-            central.scanForPeripheralsWithServices(listOf(serviceUUID), null)
+            val services: MutableList<CBUUID> = mutableListOf()
+            GattUuids.forEach { set ->
+                services.add(CBUUID.UUIDWithString(set.discoveryServiceUUID))
+            }
+            val options = mapOf<Any?, Any?>(
+                CBCentralManagerScanOptionAllowDuplicatesKey to NSNumber(false)
+            )
+            central.scanForPeripheralsWithServices(services, options)
             NSLog("BleManager: Scan started immediately")
         } else {
             scanWhenReady = true
@@ -281,7 +345,7 @@ actual class BleManager {
         centralManager?.stopScan()
         NSLog("BleManager: Scan stopped")
     }
-
+ 
     actual fun advertise() {
         if (peripheralManager == null) {
             peripheralManager = CBPeripheralManager(peripheralManagerDelegate, null)
@@ -296,8 +360,12 @@ actual class BleManager {
     }
 
     private fun startAdvertisingInternal() {
+        val services: MutableList<CBUUID> = mutableListOf()
+        GattUuids.forEach { set ->
+            services.add(CBUUID.UUIDWithString(set.discoveryServiceUUID))
+        }
         val advertisementData = mapOf<Any?, Any?>(
-            CBAdvertisementDataServiceUUIDsKey to listOf(serviceUUID),
+            CBAdvertisementDataServiceUUIDsKey to services,
             CBAdvertisementDataLocalNameKey to "UWB Device"
         )
         peripheralManager?.startAdvertising(advertisementData)
@@ -328,22 +396,23 @@ actual class BleManager {
         }
 
         // Build the GATT service
+        NSLog(("read char= ${GattUuids.find { it.name == GattName }?.readFromUUID ?: ""}"))
         val readChar = CBMutableCharacteristic(
-            type = configReadUUID,
-            properties = CBCharacteristicPropertyRead,
+            type = CBUUID.UUIDWithString(GattUuids.find { it.name == GattName }?.readFromUUID ?: ""),
+            properties = CBCharacteristicPropertyRead or CBCharacteristicPropertyNotify,
             value = null, // Dynamic value — served via delegate
             permissions = CBAttributePermissionsReadable
         )
         readCharacteristic = readChar
 
         val writeChar = CBMutableCharacteristic(
-            type = configWriteUUID,
+            type = CBUUID.UUIDWithString(GattUuids.find { it.name == GattName }?.writeToUUID ?: ""),
             properties = CBCharacteristicPropertyWrite or CBCharacteristicPropertyWriteWithoutResponse,
             value = null,
             permissions = CBAttributePermissionsWriteable
         )
 
-        val service = CBMutableService(serviceUUID, primary = true)
+        val service = CBMutableService(CBUUID.UUIDWithString(GattUuids.find { it.name == GattName }?.discoveryServiceUUID ?: ""), primary = true)
         service.setCharacteristics(listOf(readChar, writeChar))
 
         peripheralManager?.addService(service)
@@ -360,7 +429,7 @@ actual class BleManager {
     // ---- Public API: GATT Client (config exchange) ----
 
     actual fun connectAndExchangeConfig(peerId: String, localConfig: UwbSessionConfig) {
-        val peripheral = discoveredPeripherals[peerId]
+        val peripheral = discoveredPeripherals[peerId]?.bleDevice
         if (peripheral == null) {
             NSLog("BleManager: No cached peripheral for $peerId")
             return

--- a/uwbmodule/src/iosMain/kotlin/BleManager.kt
+++ b/uwbmodule/src/iosMain/kotlin/BleManager.kt
@@ -5,9 +5,10 @@ import platform.CoreBluetooth.*
 import platform.Foundation.*
 import platform.darwin.NSObject
 
-private val GattName = "us"
 @OptIn(ExperimentalForeignApi::class)
-actual class BleManager {
+actual class BleManager(
+    private val config: BleDiscoveryConfig = BleDiscoveryConfig(),
+) {
 
     private var centralManager: CBCentralManager? = null
     private var peripheralManager: CBPeripheralManager? = null
@@ -32,25 +33,28 @@ actual class BleManager {
     // Deferred operations waiting for poweredOn
     private var scanWhenReady = false
     private var advertiseWhenReady = false
+    private var gattServerWhenReady = false
 
     fun addGattService(index: Int){
+        val entry = config.profiles[index]
 
+        // Read-only for now; accessory-protocol tx-notify is future work (would add CBCharacteristicPropertyNotify).
         val readChar = CBMutableCharacteristic(
-            type = CBUUID.UUIDWithString(GattUuids[index].readFromUUID),
-            properties = CBCharacteristicPropertyRead or CBCharacteristicPropertyNotify,
+            type = CBUUID.UUIDWithString(entry.readFromUUID),
+            properties = CBCharacteristicPropertyRead,
             value = null, // Dynamic value — served via delegate
             permissions = CBAttributePermissionsReadable
         )
         readCharacteristic = readChar
 
         val writeChar = CBMutableCharacteristic(
-            type = CBUUID.UUIDWithString(GattUuids[index].readFromUUID),
+            type = CBUUID.UUIDWithString(entry.writeToUUID),
             properties = CBCharacteristicPropertyWrite or CBCharacteristicPropertyWriteWithoutResponse,
             value = null,
             permissions = CBAttributePermissionsWriteable
         )
 
-        val service = CBMutableService(CBUUID.UUIDWithString(GattUuids[index].discoveryServiceUUID ?: ""), primary = true)
+        val service = CBMutableService(CBUUID.UUIDWithString(entry.discoveryServiceUUID), primary = true)
         service.setCharacteristics(listOf(readChar, writeChar))
 
         peripheralManager?.addService(service)
@@ -67,7 +71,7 @@ actual class BleManager {
                 if (scanWhenReady) {
                     scanWhenReady = false
                     var serviceList: MutableList<CBUUID> = mutableListOf()
-                    GattUuids.forEach { set ->
+                    config.profiles.forEach { set ->
                         serviceList.add(CBUUID.UUIDWithString(set.discoveryServiceUUID))
                     }
                     central.scanForPeripheralsWithServices(serviceList, null)
@@ -96,13 +100,11 @@ actual class BleManager {
                     NSLog("discovered device service UUID= ${id.UUIDString}")
                 }
 
-                // Loop through the advertised service UUIDs to find a match
-                GattUuids.forEach { set ->
-                    //NSLog("BleManager: serviceUUID=${set.discoveryServiceUUID} - setid = ${set.discoveryServiceUUID.slice(IntRange(4,7))}")
-                    val hasTargetService =
-                        serviceUuids.any { it.UUIDString() == set.discoveryServiceUUID || "0000"+it.UUIDString ==  set.discoveryServiceUUID.slice(IntRange(0,7))
-                    }
-                    if (hasTargetService) {
+                // Match advertised service UUIDs against our profiles. CBUUID equality normalizes
+                // 16-bit (e.g. FFF0) vs full 128-bit base UUIDs, so no string slicing is needed.
+                config.profiles.forEach { set ->
+                    val target = CBUUID.UUIDWithString(set.discoveryServiceUUID)
+                    if (serviceUuids.any { it == target }) {
                         NSLog("BleManager: found set=${set.discoveryServiceUUID}")
                         service = set
                     }
@@ -148,9 +150,9 @@ actual class BleManager {
             }
             val discoveredDevice = discoveredPeripherals[peripheral.identifier.UUIDString]
             NSLog("BleManager: device service =${peripheral.services} and service on scan discover was ${discoveredDevice?.service?.discoveryServiceUUID}")
-            val service= peripheral.services?.firstOrNull {
-                (it as? CBService)?.UUID.toString() == discoveredDevice?.service?.discoveryServiceUUID?.uppercase() ||
-                "0000"+(it as? CBService)?.UUID.toString() == discoveredDevice?.service?.discoveryServiceUUID?.slice(IntRange(0,7))
+            val targetServiceUuid = discoveredDevice?.service?.discoveryServiceUUID?.let { CBUUID.UUIDWithString(it) }
+            val service = if (targetServiceUuid == null) null else peripheral.services?.firstOrNull {
+                (it as? CBService)?.UUID == targetServiceUuid
             } as? CBService
 
             if (service == null) {
@@ -267,6 +269,12 @@ actual class BleManager {
         override fun peripheralManagerDidUpdateState(peripheral: CBPeripheralManager) {
             if (peripheral.state == CBManagerStatePoweredOn) {
                 NSLog("BleManager: Peripheral manager powered on")
+                // GATT services can only be added once powered on, else CoreBluetooth rejects them
+                // with "API MISUSE … powered on state" and the peer reads invalid handles.
+                if (gattServerWhenReady) {
+                    gattServerWhenReady = false
+                    addAllGattServices()
+                }
                 if (advertiseWhenReady) {
                     advertiseWhenReady = false
                     startAdvertisingInternal()
@@ -296,13 +304,10 @@ actual class BleManager {
                 NSLog("BleManager: Failed to add service: ${error.localizedDescription}")
             } else {
                 NSLog("BleManager: GATT service added")
-                GattUuids.forEachIndexed { index, service ->
-                   NSLog("checking ${didAddService.UUID.UUIDString} against ${service.discoveryServiceUUID}")
-                    if( didAddService.UUID.UUIDString.equals(service.discoveryServiceUUID, ignoreCase = true)   ){
-                        // if we aren't on the last
-                        NSLog("BleManager: checking service index ${service.discoveryServiceUUID}")
-                        if(index <GattUuids.lastIndex)
-                        // add the next one
+                // addService is async — chain the next profile only after this one is added.
+                config.profiles.forEachIndexed { index, service ->
+                    if( didAddService.UUID == CBUUID.UUIDWithString(service.discoveryServiceUUID) ){
+                        if(index < config.profiles.lastIndex)
                             addGattService(index+1 )
                     }
                 }
@@ -313,11 +318,12 @@ actual class BleManager {
             peripheral: CBPeripheralManager,
             didReceiveReadRequest: CBATTRequest
         ) {
-        
-            val peerId =  didReceiveReadRequest.central.identifier.UUIDString()
-            val discovererDevice = discoveredPeripherals[peerId]
-            if (didReceiveReadRequest.characteristic.UUID == discovererDevice?.service?.readFromUUID?.let { CBUUID.UUIDWithString(it) }) {
-            
+            // The connecting central isn't in discoveredPeripherals (that map is filled by scanning),
+            // so match the characteristic against any hosted profile's read char.
+            val isReadChar = config.profiles.any {
+                didReceiveReadRequest.characteristic.UUID == CBUUID.UUIDWithString(it.readFromUUID)
+            }
+            if (isReadChar) {
                 val configBytes = localConfig?.toByteArray() ?: ByteArray(0)
                 val offset = didReceiveReadRequest.offset.toInt()
                 if (offset < configBytes.size) {
@@ -342,10 +348,10 @@ actual class BleManager {
             didReceiveWriteRequests.forEach { request ->
 
                 if (request is CBATTRequest) {
-                  val r:CBATTRequest =request as CBATTRequest
-                  val peerId =  r.central.identifier.UUIDString()
-                  val discovererDevice = discoveredPeripherals[peerId]
-                  if( request.characteristic.UUID == discovererDevice?.service?.writeToUUID?.let { CBUUID.UUIDWithString(it) }) {
+                  val isWriteChar = config.profiles.any {
+                      request.characteristic.UUID == CBUUID.UUIDWithString(it.writeToUUID)
+                  }
+                  if( isWriteChar ) {
                     val data = request.value
                     if (data != null) {
                         val remoteConfig = UwbSessionConfig.fromByteArray(data.toByteArray())
@@ -375,7 +381,7 @@ actual class BleManager {
 
         if (central.state == CBManagerStatePoweredOn) {
             val services: MutableList<CBUUID> = mutableListOf()
-            GattUuids.forEach { set ->
+            config.profiles.forEach { set ->
                 services.add(CBUUID.UUIDWithString(set.discoveryServiceUUID))
             }
             val options = mapOf<Any?, Any?>(
@@ -409,10 +415,7 @@ actual class BleManager {
 
     private fun startAdvertisingInternal() {
         val services: MutableList<CBUUID> = mutableListOf()
-       /* GattUuids.forEach { set ->
-            services.add(CBUUID.UUIDWithString(set.discoveryServiceUUID))
-        }*/
-        val uidstring = GattUuids.find { it.name == GattName }?.discoveryServiceUUID ?: ""
+        val uidstring = config.profiles.find { it.name == config.advertiseProfile }?.discoveryServiceUUID ?: ""
         services.add(CBUUID.UUIDWithString(uidstring))
         val advertisementData = mapOf<Any?, Any?>(
             CBAdvertisementDataServiceUUIDsKey to services,
@@ -444,10 +447,20 @@ actual class BleManager {
         if (peripheralManager == null) {
             peripheralManager = CBPeripheralManager(peripheralManagerDelegate, null)
         }
-        GattUuids.forEachIndexed { index, entry ->
-            addGattService(index)
-        }
 
+        if (peripheralManager?.state == CBManagerStatePoweredOn) {
+            addAllGattServices()
+        } else {
+            gattServerWhenReady = true
+            NSLog("BleManager: GATT server deferred until powered on")
+        }
+    }
+
+    /** Adds the first profile's service; the rest are chained via the didAddService delegate. */
+    private fun addAllGattServices() {
+        if (config.profiles.isNotEmpty()) {
+            addGattService(0)
+        }
     }
 
     actual fun stopGattServer() {

--- a/uwbmodule/src/iosMain/kotlin/ManagerFactory.ios.kt
+++ b/uwbmodule/src/iosMain/kotlin/ManagerFactory.ios.kt
@@ -5,7 +5,7 @@ actual class ManagerFactory {
         return MultiplatformUwbManager()
     }
 
-    actual fun createBleManager(): BleManager {
-        return BleManager()
+    actual fun createBleManager(config: BleDiscoveryConfig): BleManager {
+        return BleManager(config)
     }
 }

--- a/uwbmodule/src/iosMain/kotlin/MultiplatformUwbManager.ios.kt
+++ b/uwbmodule/src/iosMain/kotlin/MultiplatformUwbManager.ios.kt
@@ -46,7 +46,10 @@ actual class MultiplatformUwbManager {
     /** Strong reference to delegate to prevent GC. */
     private var sessionDelegate: SessionDelegate? = null
 
-    actual suspend fun initialize() {
+    /*actual suspend fun initialize(){
+
+    }*/
+     actual suspend fun initialize() {
         if (!NISession.isSupported()) {
             errorCallback?.invoke("NearbyInteraction not supported on this device")
             return


### PR DESCRIPTION
Builds directly on top of @sdetweil's #9 (`multi_uuid`) — this branch contains all of his commits plus one fix commit, so it can either supersede #9 or he can cherry-pick. Compiles clean for Android (`compileDebugKotlinAndroid`) and iOS (`compileKotlinIosSimulatorArm64`).

## App-owned configuration (replaces the module globals)
Per the discussion, the library shouldn't bake in a profile or a vendor. Replaced the mutable global `var GattUuids` array and the per-platform `GattName` with an injected config object:

```kotlin
data class BleDiscoveryConfig(
    val profiles: List<ServiceEntry> = DEFAULT_PROFILES,         // scanned + served
    val advertiseProfile: String = DEFAULT_PROFILES.first().name // this device's identity
)
```

- Threaded via `ManagerFactory.createBleManager(config: BleDiscoveryConfig = BleDiscoveryConfig())` → each `BleManager` actual constructor. No change to the `@Composable createManagerFactory()` signature; the app/init passes a config (or takes the default).
- **Default is vendor-free**: one generic `local` profile (the FFF0/FFF1/FFF2 set). `QORVO_NEARBY_PROFILE` and `NORDIC_NEARBY_PROFILE` ship as opt-in `ServiceEntry` constants an app adds explicitly, e.g. `createBleManager(BleDiscoveryConfig(profiles = DEFAULT_PROFILES + QORVO_NEARBY_PROFILE))`.

## Android fixes
- **Server characteristic matching** was case-sensitive (`uuid.toString()` lowercase vs `.uppercase()`) and keyed on `discoveredDevices[device.address]`, which is filled by *scanning* and is empty in the server role. Now matches the characteristic against any hosted profile's read/write char, case-insensitively — role-independent. *(This is the "what does server mean" point: both phones run a client and a server; the server callback can't reuse the scan map.)*
- **Client read handler** compared a `UUID` to a `BluetoothGattCharacteristic` (always false), so the read result was never processed and the write-back never fired. Now `UUID == UUID`.
- Dropped the no-op `or CALLBACK_TYPE_FIRST_MATCH` from `setScanMode`.
- Dropped `PROPERTY_NOTIFY` (the flow is read/write; CCCD + notify is future accessory-protocol work).

## iOS fixes
- **GATT server is now deferred until powered on** — it was calling `addService` before `CBManagerStatePoweredOn`, which is the root of the `API MISUSE … powered on state` logs and the "invalid handle" reads. Services add in the powered-on delegate and chain via `didAddService`.
- Removed the `UUIDString()` **function-call compile errors** (it's a property).
- Replaced the `"0000"+slice(...)` string hacks with **CBUUID equality**, which normalizes 16-bit (`FFF0`) vs 128-bit base UUIDs — fixes the `local`/FFF0 match cleanly. Server matching is role-independent like Android.
- Fixed the write characteristic that was built from `readFromUUID`; dropped the notify property.

## The case-insensitive snippet (re: the compile error you hit)
Comparing the `String` UUIDs: `a.equals(b, ignoreCase = true)` (returns `Boolean`). Comparing parsed UUIDs: `characteristic.uuid == UUID.fromString(s)`. On iOS, compare `CBUUID` objects directly (`x == CBUUID.UUIDWithString(s)`) rather than strings.

## Out of scope (still TODO)
- Apple Nearby-Interaction **accessory-protocol config payload** — needed for real Android↔iOS *ranging*; until then the BLE exchange completes but ranging fails (expected). This is where your firmware's new profile + the iOS `NINearbyAccessoryConfiguration` path come in.
- UI to pick the profile.
- **iOS GATT cache**: stale handles from earlier dev builds can linger — toggle Bluetooth / forget the device once if a peer shows phantom services.

## Testing
Compiles on both targets here; I don't have two devices. Best validated on two Android phones first (default `local` profile): both should discover, connect, exchange config, and reach "Starting ranging" with a distance.

Refs #5, supersedes/continues #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)