### PR TITLE
iOS: add NSNearbyInteractionUsageDescription (fixes NIERROR_USER_DID_NOT_ALLOW)

### DIFF
--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -51,5 +51,7 @@
 	<string>This app uses Bluetooth to discover nearby UWB devices for precise ranging</string>
 	<key>NSBluetoothPeripheralUsageDescription</key>
 	<string>This app uses Bluetooth to advertise UWB capabilities to other devices</string>
+	<key>NSNearbyInteractionUsageDescription</key>
+	<string>This app uses Nearby Interaction to measure precise distance and direction to nearby UWB devices</string>
 </dict>
 </plist>


### PR DESCRIPTION
Fixes #13.

## Diagnosis
The log shows the BLE config exchange succeeding, then the NI session dying immediately:

```
UwbManager: Starting ranging with 0B1AB623-…
UwbManager: Session invalidated: NIERROR_USER_DID_NOT_ALLOW_DESCRIPTION
```

`NIERROR_USER_DID_NOT_ALLOW` is the Nearby Interaction permission being denied. The app already declares the `nearby-interaction` required device capability and runs an `NISession`, but `iosApp/iosApp/Info.plist` was **missing `NSNearbyInteractionUsageDescription`**. Without that usage string iOS can't present the permission prompt, so the session is denied the moment it starts — exactly at the point the log dies.

## Fix
Add the usage description key (validated with `plutil -lint`):

```xml
<key>NSNearbyInteractionUsageDescription</key>
<string>This app uses Nearby Interaction to measure precise distance and direction to nearby UWB devices</string>
```

## Testing
Plist lints OK. On device, first launch should now show the Nearby Interaction permission prompt; allowing it lets the `NISession` start instead of invalidating. (If a build was already run once and denied, iOS remembers — reset via Settings → the app, or reinstall, to see the prompt again.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)