### PR TITLE
Fix Android UWB ranging: exchange 8-byte static-STS session key (#11)

### DIFF
--- a/uwbmodule/src/androidMain/kotlin/MultiplatformUwbManager.android.kt
+++ b/uwbmodule/src/androidMain/kotlin/MultiplatformUwbManager.android.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.launch
+import java.security.SecureRandom
 
 actual class MultiplatformUwbManager(private val androidUwbManager: UwbManager? = null) {
     private val TAG = "UwbManager"
@@ -29,10 +30,17 @@ actual class MultiplatformUwbManager(private val androidUwbManager: UwbManager? 
     /** Active ranging coroutine jobs, keyed by peer ID. Cancel to stop ranging. */
     private val activeJobs = mutableMapOf<String, Job>()
 
+    /**
+     * Our 8-byte static-STS session key, generated once and reused for the lifetime
+     * of this manager so the value advertised over BLE matches the one used at ranging.
+     */
+    private var localSessionKey: ByteArray? = null
+
     /** Default channel and preamble — used when generating local config. */
     private companion object {
         const val DEFAULT_CHANNEL = 9
         const val DEFAULT_PREAMBLE_INDEX = 10
+        const val SESSION_KEY_SIZE = 8
     }
 
     actual suspend fun initialize() {
@@ -63,12 +71,19 @@ actual class MultiplatformUwbManager(private val androidUwbManager: UwbManager? 
         // (the peer with the lexicographically smaller address initiates).
         val sessionId = localAddress.fold(0) { acc, b -> acc * 31 + (b.toInt() and 0xFF) }
 
+        // Generate the static-STS key lazily and cache it, so the key we send over
+        // BLE is the same one we compare/use when ranging starts.
+        val key = localSessionKey ?: ByteArray(SESSION_KEY_SIZE)
+            .also { SecureRandom().nextBytes(it) }
+            .also { localSessionKey = it }
+
         return UwbSessionConfig(
             sessionId = sessionId,
             channel = DEFAULT_CHANNEL,
             preambleIndex = DEFAULT_PREAMBLE_INDEX,
             uwbAddress = localAddress,
             discoveryToken = null,
+            sessionKey = key,
         )
     }
 
@@ -88,24 +103,39 @@ actual class MultiplatformUwbManager(private val androidUwbManager: UwbManager? 
                 val peerAddress = UwbAddress(remoteConfig.uwbAddress)
                 val peerDevice = UwbDevice(peerAddress)
 
-                // Deterministic session ID: use the smaller of the two proposed IDs
-                // so both peers agree without extra negotiation.
+                // Deterministic agreement without a handshake: the peer with the
+                // lexicographically smaller UWB address is the initiator, and both
+                // peers adopt its full parameter set (session ID, channel, preamble,
+                // and static-STS key). Both ends hold both configs after the BLE
+                // exchange, so they independently compute the same values.
                 val localConfig = getLocalConfig()
-                val agreedSessionId = if (localConfig != null) {
-                    minOf(localConfig.sessionId, remoteConfig.sessionId)
+                val agreed = if (localConfig != null &&
+                    compareAddresses(localConfig.uwbAddress, remoteConfig.uwbAddress) <= 0
+                ) {
+                    localConfig
                 } else {
-                    remoteConfig.sessionId
+                    remoteConfig
+                }
+
+                val sessionKey = agreed.sessionKey
+                if (sessionKey == null || sessionKey.size != SESSION_KEY_SIZE) {
+                    errorCallback?.invoke(
+                        "Cannot range with $peerId: missing or invalid session key " +
+                                "(static STS requires $SESSION_KEY_SIZE bytes)"
+                    )
+                    activeJobs.remove(peerId)
+                    return@launch
                 }
 
                 val rangingParameters = RangingParameters(
                     uwbConfigType = RangingParameters.CONFIG_UNICAST_DS_TWR,
-                    sessionId = agreedSessionId,
+                    sessionId = agreed.sessionId,
                     subSessionId = 0,
-                    sessionKeyInfo = null,
+                    sessionKeyInfo = sessionKey,
                     subSessionKeyInfo = null,
                     complexChannel = UwbComplexChannel(
-                        channel = remoteConfig.channel,
-                        preambleIndex = remoteConfig.preambleIndex
+                        channel = agreed.channel,
+                        preambleIndex = agreed.preambleIndex
                     ),
                     peerDevices = listOf(peerDevice),
                     updateRateType = RangingParameters.RANGING_UPDATE_RATE_AUTOMATIC
@@ -113,7 +143,7 @@ actual class MultiplatformUwbManager(private val androidUwbManager: UwbManager? 
 
                 Log.d(
                     TAG,
-                    "Starting ranging with $peerId — session=$agreedSessionId ch=${remoteConfig.channel}"
+                    "Starting ranging with $peerId — session=${agreed.sessionId} ch=${agreed.channel}"
                 )
 
                 scope.prepareSession(rangingParameters)
@@ -161,6 +191,19 @@ actual class MultiplatformUwbManager(private val androidUwbManager: UwbManager? 
 
     actual fun setErrorCallback(callback: (error: String) -> Unit) {
         errorCallback = callback
+    }
+
+    /**
+     * Compare two UWB addresses lexicographically (unsigned, byte by byte).
+     * Returns a negative value if [a] sorts before [b], positive if after, 0 if equal.
+     */
+    private fun compareAddresses(a: ByteArray, b: ByteArray): Int {
+        val len = minOf(a.size, b.size)
+        for (i in 0 until len) {
+            val diff = (a[i].toInt() and 0xFF) - (b[i].toInt() and 0xFF)
+            if (diff != 0) return diff
+        }
+        return a.size - b.size
     }
 
     /** Stop all sessions and clean up resources. */

--- a/uwbmodule/src/commonMain/kotlin/UwbSessionConfig.kt
+++ b/uwbmodule/src/commonMain/kotlin/UwbSessionConfig.kt
@@ -17,6 +17,13 @@ data class UwbSessionConfig(
     val uwbAddress: ByteArray,
     /** Serialized NI discovery token (iOS) or null (Android). */
     val discoveryToken: ByteArray? = null,
+    /**
+     * 8-byte static-STS session key (Android) or null (iOS).
+     *
+     * Required by androidx.core.uwb for `CONFIG_UNICAST_DS_TWR`; both peers must
+     * use the same key. Exchanged here so the two ends can agree on one.
+     */
+    val sessionKey: ByteArray? = null,
 ) {
     /**
      * Serialize to a simple binary format for BLE GATT exchange.
@@ -26,11 +33,14 @@ data class UwbSessionConfig(
      * [1B version][4B sessionId][4B channel][4B preambleIndex]
      * [2B uwbAddr.size][uwbAddr bytes]
      * [2B token.size][token bytes]   // size=0 if null
+     * [2B key.size][key bytes]       // optional trailer; absent or size=0 if null
      * ```
+     * The session-key trailer is optional so older payloads (without it) still parse.
      */
     fun toByteArray(): ByteArray {
         val tokenBytes = discoveryToken ?: ByteArray(0)
-        val size = 1 + 4 + 4 + 4 + 2 + uwbAddress.size + 2 + tokenBytes.size
+        val keyBytes = sessionKey ?: ByteArray(0)
+        val size = 1 + 4 + 4 + 4 + 2 + uwbAddress.size + 2 + tokenBytes.size + 2 + keyBytes.size
         val buf = ByteArray(size)
         var pos = 0
 
@@ -65,6 +75,12 @@ data class UwbSessionConfig(
         buf[pos++] = (tokenBytes.size shr 8).toByte()
         buf[pos++] = tokenBytes.size.toByte()
         tokenBytes.copyInto(buf, pos)
+        pos += tokenBytes.size
+
+        // sessionKey
+        buf[pos++] = (keyBytes.size shr 8).toByte()
+        buf[pos++] = keyBytes.size.toByte()
+        keyBytes.copyInto(buf, pos)
 
         return buf
     }
@@ -74,11 +90,14 @@ data class UwbSessionConfig(
         if (other !is UwbSessionConfig) return false
         val thisToken = discoveryToken ?: ByteArray(0)
         val otherToken = other.discoveryToken ?: ByteArray(0)
+        val thisKey = sessionKey ?: ByteArray(0)
+        val otherKey = other.sessionKey ?: ByteArray(0)
         return sessionId == other.sessionId &&
                 channel == other.channel &&
                 preambleIndex == other.preambleIndex &&
                 uwbAddress.contentEquals(other.uwbAddress) &&
-                thisToken.contentEquals(otherToken)
+                thisToken.contentEquals(otherToken) &&
+                thisKey.contentEquals(otherKey)
     }
 
     override fun hashCode(): Int {
@@ -87,6 +106,7 @@ data class UwbSessionConfig(
         result = 31 * result + preambleIndex
         result = 31 * result + uwbAddress.contentHashCode()
         result = 31 * result + (discoveryToken?.contentHashCode() ?: 0)
+        result = 31 * result + (sessionKey?.contentHashCode() ?: 0)
         return result
     }
 
@@ -113,6 +133,15 @@ data class UwbSessionConfig(
             val tokenLen = readShort(bytes, pos); pos += 2
             if (pos + tokenLen > bytes.size) return null
             val discoveryToken = if (tokenLen > 0) bytes.copyOfRange(pos, pos + tokenLen) else null
+            pos += tokenLen
+
+            // Optional session-key trailer (absent in older payloads).
+            val sessionKey = if (pos + 2 <= bytes.size) {
+                val keyLen = readShort(bytes, pos); pos += 2
+                if (keyLen > 0 && pos + keyLen <= bytes.size) bytes.copyOfRange(pos, pos + keyLen) else null
+            } else {
+                null
+            }
 
             return UwbSessionConfig(
                 sessionId = sessionId,
@@ -120,6 +149,7 @@ data class UwbSessionConfig(
                 preambleIndex = preambleIndex,
                 uwbAddress = uwbAddress,
                 discoveryToken = discoveryToken,
+                sessionKey = sessionKey,
             )
         }
 

--- a/uwbmodule/src/commonTest/kotlin/com/dustedrob/uwb/UwbSessionConfigTest.kt
+++ b/uwbmodule/src/commonTest/kotlin/com/dustedrob/uwb/UwbSessionConfigTest.kt
@@ -99,4 +99,64 @@ class UwbSessionConfigTest {
         assertEquals(a, b)
         assertEquals(a.hashCode(), b.hashCode())
     }
+
+    @Test
+    fun roundtripWithSessionKey() {
+        val key = byteArrayOf(1, 2, 3, 4, 5, 6, 7, 8)
+        val config = UwbSessionConfig(
+            sessionId = 4382,
+            channel = 9,
+            preambleIndex = 10,
+            uwbAddress = byteArrayOf(0x86.toByte(), 0xE4.toByte()),
+            discoveryToken = null,
+            sessionKey = key,
+        )
+        val bytes = config.toByteArray()
+        val restored = UwbSessionConfig.fromByteArray(bytes)
+        assertNotNull(restored)
+        assertNotNull(restored.sessionKey)
+        assertTrue(key.contentEquals(restored.sessionKey!!))
+        assertEquals(config, restored)
+    }
+
+    @Test
+    fun roundtripWithBothTokenAndKey() {
+        val token = byteArrayOf(0xAA.toByte(), 0xBB.toByte())
+        val key = ByteArray(8) { it.toByte() }
+        val config = UwbSessionConfig(7, 9, 10, byteArrayOf(0x01), token, key)
+        val restored = UwbSessionConfig.fromByteArray(config.toByteArray())
+        assertNotNull(restored)
+        assertTrue(token.contentEquals(restored.discoveryToken!!))
+        assertTrue(key.contentEquals(restored.sessionKey!!))
+    }
+
+    @Test
+    fun sessionKeyNullWhenAbsent() {
+        val config = UwbSessionConfig(1, 2, 3, byteArrayOf(9), discoveryToken = byteArrayOf(1, 2))
+        val restored = UwbSessionConfig.fromByteArray(config.toByteArray())
+        assertNotNull(restored)
+        assertNull(restored.sessionKey)
+    }
+
+    @Test
+    fun parsesLegacyPayloadWithoutKeyTrailer() {
+        // A payload from before the session-key trailer existed: it ends right after
+        // the discovery-token block, with no [2B key.size] trailer at all.
+        val sid = 42
+        val ch = 9
+        val pre = 10
+        val addr = byteArrayOf(0x01, 0x02)
+        val legacy = byteArrayOf(
+            1, // version
+            (sid shr 24).toByte(), (sid shr 16).toByte(), (sid shr 8).toByte(), sid.toByte(),
+            (ch shr 24).toByte(), (ch shr 16).toByte(), (ch shr 8).toByte(), ch.toByte(),
+            (pre shr 24).toByte(), (pre shr 16).toByte(), (pre shr 8).toByte(), pre.toByte(),
+            (addr.size shr 8).toByte(), addr.size.toByte(), addr[0], addr[1],
+            0, 0, // token size = 0
+        )
+        val restored = UwbSessionConfig.fromByteArray(legacy)
+        assertNotNull(restored)
+        assertEquals(sid, restored.sessionId)
+        assertNull(restored.sessionKey)
+    }
 }


### PR DESCRIPTION
## Problem
  
  Android ranging used `CONFIG_UNICAST_DS_TWR` with `sessionKeyInfo = null`, but
  `androidx.core.uwb` requires an 8-byte session key for static STS. So ranging
  failed for **every** Android peer:
  
  > Failed to start ranging: Session key should be 8 bytes in length for static STS.
  
  (See #11.) Android↔Android never actually reached a distance because of this.
  
  ## Fix
  
  - **`UwbSessionConfig`**: add an optional 8-byte `sessionKey` field, serialized as a
    backward-compatible trailer (older / key-less payloads still parse, e.g. iOS).
  - **Android**: generate and cache an 8-byte key, include it in the local config,
    and pass it as `sessionKeyInfo` when ranging.
  - **Android**: agree on *all* ranging parameters deterministically , the peer with
    the smaller UWB address is the initiator, and both ends adopt its session ID,
    channel, preamble, and key. Replaces the inconsistent "min(sessionId) + remote
    channel" logic, so both sides compute identical values with no handshake.
    