### PR TITLE
Use optional advertised UUID to locate service entry

### DIFF
--- a/uwbmodule/src/androidMain/kotlin/BleManager.kt
+++ b/uwbmodule/src/androidMain/kotlin/BleManager.kt
@@ -73,11 +73,12 @@ actual class BleManager(
             }
             if(discoveredDevices[deviceAddress] == null) {
                 result.scanRecord?.serviceUuids?.forEach { uuid ->
+                    Log.d(TAG, "scan discovered id=${uuid}")
                     config.profiles.forEach { serviceEntry ->
-                        if (serviceEntry.discoveryServiceUUID.uppercase() == uuid.toString()
-                                .uppercase()
+                        if (serviceEntry.advertisedUUID?.equals(uuid.toString(), true) == true
                         )
                             if (service == null) {
+                                Log.d(TAG, "found matching service entry = ${serviceEntry.advertisedUUID}")
                                 service = serviceEntry
                             }
                     }
@@ -131,13 +132,19 @@ actual class BleManager(
             Log.d(TAG,"Service Added ${service?.uuid.toString()}, status=${status}")
             // addService() is async — chain the next profile's service only after this one is added.
             config.profiles.forEachIndexed { index, entry ->
-                if( service?.uuid.toString().equals(entry.discoveryServiceUUID, ignoreCase = true) ||
-                    service?.uuid.toString().equals(entry.discoveryServiceUUID.slice(IntRange(4,7)), ignoreCase = true)
-                    ){
-                    // if we aren't on the last
-                    if(index < config.profiles.lastIndex)
+                if(service?.uuid.toString() == entry.advertisedUUID) {
+                    if (service?.uuid.toString()
+                            .equals(entry.discoveryServiceUUID, ignoreCase = true) ||
+                        service?.uuid.toString().equals(
+                            entry.discoveryServiceUUID.slice(IntRange(4, 7)),
+                            ignoreCase = true
+                        )
+                    ) {
+                        // if we aren't on the last
+                        if (index < config.profiles.size - 1)
                         // add the next one
-                        addGattService(index+1 )
+                            addGattService(config.profiles[index + 1])
+                    }
                 }
             }
 
@@ -186,7 +193,7 @@ actual class BleManager(
             }
             if (isWriteChar && value != null) {
                 gattServer?.sendResponse(device, requestId, BluetoothGatt.GATT_SUCCESS, 0, null)
-
+                Log.d(TAG, "read config bytes=${value.size}")
                 val remoteConfig = UwbSessionConfig.fromByteArray(value)
                 if (remoteConfig != null) {
                     Log.d(TAG, "GATT server: received config from ${device.address}")
@@ -253,8 +260,9 @@ actual class BleManager(
 
             var filters: MutableList<ScanFilter> = mutableListOf()
             config.profiles.forEach { serviceEntry ->
+                Log.d(TAG,"adding scan for id=${serviceEntry.advertisedUUID}")
                 val scanFilter = ScanFilter.Builder()
-                    .setServiceUuid(ParcelUuid(UUID.fromString(serviceEntry.discoveryServiceUUID.uppercase())))
+                    .setServiceUuid(ParcelUuid(UUID.fromString(serviceEntry.advertisedUUID?.uppercase())))
                     .build()
                 filters.add(scanFilter)
             }
@@ -355,11 +363,14 @@ actual class BleManager(
             Log.e(TAG, "Missing BLUETOOTH_CONNECT permission for GATT server")
             return
         }
-
+        config.profiles.forEach { set ->
+            if(set.advertisedUUID == null)
+                set.advertisedUUID = set.discoveryServiceUUID
+        }
         try {
             val server= bluetoothManager.openGattServer(context, gattServerCallback)
             gattServer = server
-            addGattService(0)
+            addGattService( config.profiles[0])
             Log.d(TAG, "GATT server started")
         } catch (e: Exception) {
             Log.e(TAG, "Error starting GATT server: ${e.message}")
@@ -380,19 +391,19 @@ actual class BleManager(
 
     // ---- Public API: GATT Client (config exchange) ----
     @RequiresPermission(BLUETOOTH_CONNECT)
-    fun addGattService(index:Int){
+    fun addGattService(entry:ServiceEntry){
 
             // Build the UWB config service. All profiles are PRIMARY so each is independently
             // discoverable by a connecting client.
             val service = BluetoothGattService(
-                UUID.fromString(config.profiles[index].discoveryServiceUUID.uppercase()),
+                UUID.fromString(entry.discoveryServiceUUID.uppercase()),
                 BluetoothGattService.SERVICE_TYPE_PRIMARY
             )
 
             // Readable characteristic: our local config. (Read-only for now; the accessory-protocol
             // tx-notify flow would also need a CCCD descriptor + notifyCharacteristicChanged — future work.)
             val readChar = BluetoothGattCharacteristic(
-                UUID.fromString(config.profiles[index].readFromUUID.uppercase()),
+                UUID.fromString(entry.readFromUUID.uppercase()),
                 BluetoothGattCharacteristic.PROPERTY_READ,
                 BluetoothGattCharacteristic.PERMISSION_READ
             )
@@ -400,7 +411,7 @@ actual class BleManager(
 
             // Writable characteristic: peer writes their config here
             val writeChar = BluetoothGattCharacteristic(
-                UUID.fromString(config.profiles[index].writeToUUID.uppercase()),
+                UUID.fromString(entry.writeToUUID.uppercase()),
                 BluetoothGattCharacteristic.PROPERTY_WRITE,
                 BluetoothGattCharacteristic.PERMISSION_WRITE
             )
@@ -421,10 +432,11 @@ actual class BleManager(
             Log.e(TAG, "Missing BLUETOOTH_CONNECT permission for GATT client")
             return
         }
-        val serviceEntry: ServiceEntry? = discoveredDevices[peerId]?.service ?: null
+        val serviceEntry: ServiceEntry? = discoveredDevices[peerId]?.service
 
         try {
             device.connectGatt(context, false, object : BluetoothGattCallback() {
+
                 @RequiresPermission(BLUETOOTH_CONNECT)
                 override fun onConnectionStateChange(gatt: BluetoothGatt, status: Int, newState: Int) {
                     if (newState == BluetoothProfile.STATE_CONNECTED) {
@@ -443,11 +455,9 @@ actual class BleManager(
                         gatt.close()
                         return
                     }
-                    gatt.services.forEach { service ->
-                        Log.d(TAG, "service name found = ${service.uuid.toString()}")
-                    }
 
                     val service = gatt.getService(UUID.fromString(serviceEntry?.discoveryServiceUUID?.uppercase()))
+                    Log.d(TAG, "service found = ${service.uuid}")
                     if (service == null) {
                         Log.e(TAG, "GATT client: UWB config service not found on $peerId")
                         gatt.close()
@@ -479,6 +489,7 @@ actual class BleManager(
                     val service = gatt.getService(UUID.fromString(serviceEntry?.discoveryServiceUUID?.uppercase()))
                     if (characteristic.uuid == UUID.fromString(serviceEntry?.readFromUUID?.uppercase())) {
                         val remoteConfigBytes = characteristic.value
+                        Log.d(TAG, "read config size=${remoteConfigBytes.size}")
                         val remoteConfig = remoteConfigBytes?.let { UwbSessionConfig.fromByteArray(it) }
 
                         if (remoteConfig != null) {

--- a/uwbmodule/src/androidMain/kotlin/BleManager.kt
+++ b/uwbmodule/src/androidMain/kotlin/BleManager.kt
@@ -132,7 +132,7 @@ actual class BleManager(
             // addService() is async — chain the next profile's service only after this one is added.
             config.profiles.forEachIndexed { index, entry ->
                 if( service?.uuid.toString().equals(entry.discoveryServiceUUID, ignoreCase = true) ||
-                    service?.uuid.toString().equals(entry.discoveryServiceUUID.slice(ItnRage(4,7)), ignoreCase = true)
+                    service?.uuid.toString().equals(entry.discoveryServiceUUID.slice(IntRange(4,7)), ignoreCase = true)
                     ){
                     // if we aren't on the last
                     if(index < config.profiles.lastIndex)

--- a/uwbmodule/src/androidMain/kotlin/BleManager.kt
+++ b/uwbmodule/src/androidMain/kotlin/BleManager.kt
@@ -131,7 +131,9 @@ actual class BleManager(
             Log.d(TAG,"Service Added ${service?.uuid.toString()}, status=${status}")
             // addService() is async — chain the next profile's service only after this one is added.
             config.profiles.forEachIndexed { index, entry ->
-                if( service?.uuid.toString().equals(entry.discoveryServiceUUID, ignoreCase = true)   ){
+                if( service?.uuid.toString().equals(entry.discoveryServiceUUID, ignoreCase = true) ||
+                    service?.uuid.toString().equals(entry.discoveryServiceUUID.slice(ItnRage(4,7)), ignoreCase = true)
+                    ){
                     // if we aren't on the last
                     if(index < config.profiles.lastIndex)
                         // add the next one
@@ -151,7 +153,8 @@ actual class BleManager(
             // The connecting central isn't in discoveredDevices (that map is filled by scanning, not
             // the server role), so match the characteristic against any hosted profile's read char.
             val isReadChar = config.profiles.any {
-                it.readFromUUID.equals(characteristic.uuid.toString(), ignoreCase = true)
+                it.readFromUUID.equals(characteristic.uuid.toString(), ignoreCase = true) ||
+                it.readFromUUID.slice(IntRange(4,7)).equals(characteristic.uuid.toString(), ignoreCase = true)
             }
             if (isReadChar) {
                 val configBytes = localConfig?.toByteArray() ?: ByteArray(0)
@@ -179,6 +182,7 @@ actual class BleManager(
         ) {
             val isWriteChar = config.profiles.any {
                 it.writeToUUID.equals(characteristic.uuid.toString(), ignoreCase = true)
+                it.writeToUUID.slice(IntRange(4,7)).equals(characteristic.uuid.toString(), ignoreCase = true)
             }
             if (isWriteChar && value != null) {
                 gattServer?.sendResponse(device, requestId, BluetoothGatt.GATT_SUCCESS, 0, null)

--- a/uwbmodule/src/androidMain/kotlin/BleManager.kt
+++ b/uwbmodule/src/androidMain/kotlin/BleManager.kt
@@ -181,7 +181,7 @@ actual class BleManager(
             value: ByteArray?
         ) {
             val isWriteChar = config.profiles.any {
-                it.writeToUUID.equals(characteristic.uuid.toString(), ignoreCase = true)
+                it.writeToUUID.equals(characteristic.uuid.toString(), ignoreCase = true) ||
                 it.writeToUUID.slice(IntRange(4,7)).equals(characteristic.uuid.toString(), ignoreCase = true)
             }
             if (isWriteChar && value != null) {

--- a/uwbmodule/src/commonMain/kotlin/GattUuids.kt
+++ b/uwbmodule/src/commonMain/kotlin/GattUuids.kt
@@ -25,6 +25,7 @@ data class ServiceEntry(
     val readFromUUID: String,
     /** Characteristic the client writes its own config to (the peer's "rx"). */
     val writeToUUID: String,
+    var advertisedUUID: String? = null
 )
 
 /** This project's own (vendor-neutral) GATT service for UWB config exchange. */
@@ -37,7 +38,7 @@ const val UWB_CONFIG_CHAR_UUID = "0000FFF1-0000-1000-8000-00805F9B34FB"
 const val UWB_CONFIG_WRITE_CHAR_UUID = "0000FFF2-0000-1000-8000-00805F9B34FB"
 
 /** The library's own profile — the default identity a device advertises and exchanges config over. */
-val LOCAL_PROFILE = ServiceEntry(
+var LOCAL_PROFILE = ServiceEntry(
     name = "local",
     discoveryServiceUUID = UWB_CONFIG_SERVICE_UUID,
     readFromUUID = UWB_CONFIG_CHAR_UUID,
@@ -67,8 +68,16 @@ val NORDIC_NEARBY_PROFILE = ServiceEntry(
     writeToUUID = "6E400002-B5A3-F393-E0A9-E50E24DCCA9E",
 )
 
+val CNBeacon = ServiceEntry (
+    name="CN_Beacon",
+    discoveryServiceUUID = "2E938FD0-6A61-11ED-A1EB-0242AC120002",
+    readFromUUID = "2E93941C-6A61-11ED-A1EB-0242AC120002",
+    writeToUUID = "2E93998A-6A61-11ED-A1EB-0242AC120002",
+    "11000000-27b9-42f0-82aa-2e951747bbf9"
+)
+
 /** Vendor-free default: only the library's own [LOCAL_PROFILE]. Apps add vendor profiles explicitly. */
-val DEFAULT_PROFILES = listOf(LOCAL_PROFILE)
+val DEFAULT_PROFILES = listOf(LOCAL_PROFILE, QORVO_NEARBY_PROFILE, NORDIC_NEARBY_PROFILE, CNBeacon)
 
 /**
  * App-owned configuration for BLE discovery and config exchange.

--- a/uwbmodule/src/iosMain/kotlin/BleManager.kt
+++ b/uwbmodule/src/iosMain/kotlin/BleManager.kt
@@ -35,8 +35,9 @@ actual class BleManager(
     private var advertiseWhenReady = false
     private var gattServerWhenReady = false
 
-    fun addGattService(index: Int){
-        val entry = config.profiles[index]
+    fun addGattService(entry: ServiceEntry){
+        NSLog("BleManager: addGATTService on entry $entry")
+        //val entry = config.profiles[index]
 
         // Read-only for now; accessory-protocol tx-notify is future work (would add CBCharacteristicPropertyNotify).
         val readChar = CBMutableCharacteristic(
@@ -58,7 +59,7 @@ actual class BleManager(
         service.setCharacteristics(listOf(readChar, writeChar))
 
         peripheralManager?.addService(service)
-        NSLog("BleManager: GATT service added")
+        //NSLog("BleManager: GATT service added index=$index")
     }
 
     // ---- Central (scanner/client) delegate ----
@@ -72,8 +73,9 @@ actual class BleManager(
                     scanWhenReady = false
                     var serviceList: MutableList<CBUUID> = mutableListOf()
                     config.profiles.forEach { set ->
-                        serviceList.add(CBUUID.UUIDWithString(set.discoveryServiceUUID))
+                        set.advertisedUUID?.let { serviceList.add(CBUUID.UUIDWithString(it)) }
                     }
+                    NSLog("services to scan for are {$serviceList} ")
                     central.scanForPeripheralsWithServices(serviceList, null)
                     NSLog("BleManager: Deferred scan started")
                 }
@@ -88,7 +90,7 @@ actual class BleManager(
             advertisementData: Map<Any?, *>,
             RSSI: NSNumber
         ) {
-            val deviceId = didDiscoverPeripheral.identifier.UUIDString
+            val deviceId = didDiscoverPeripheral.hash.toString()
             if( discoveredPeripherals[deviceId] == null) {
                 val deviceName = didDiscoverPeripheral.name ?: "Unknown Device"
 
@@ -103,7 +105,7 @@ actual class BleManager(
                 // Match advertised service UUIDs against our profiles. CBUUID equality normalizes
                 // 16-bit (e.g. FFF0) vs full 128-bit base UUIDs, so no string slicing is needed.
                 config.profiles.forEach { set ->
-                    val target = CBUUID.UUIDWithString(set.discoveryServiceUUID)
+                    val target = set.advertisedUUID?.let { CBUUID.UUIDWithString(it) }
                     if (serviceUuids.any { it == target }) {
                         service = set
                     }
@@ -122,14 +124,14 @@ actual class BleManager(
             central: CBCentralManager,
             didConnectPeripheral: CBPeripheral
         ) {
-            val deviceId = didConnectPeripheral.identifier.UUIDString
+            val deviceId = didConnectPeripheral.hash.toString()
             val device = discoveredPeripherals[deviceId]
             NSLog("BleManager: Connected to $deviceId, discovering services")
             didConnectPeripheral.delegate = peripheralClientDelegate
             val services: MutableList<CBUUID> = mutableListOf()
             NSLog("BleManager: discovering services from")
-            NSLog( discoveredPeripherals[deviceId]?.service?.discoveryServiceUUID?:"")
-            services.add(CBUUID.UUIDWithString((discoveredPeripherals[deviceId]?.service?.discoveryServiceUUID?:"").uppercase()))
+            NSLog( discoveredPeripherals[deviceId]?.service?.advertisedUUID?:"")
+            services.add(CBUUID.UUIDWithString((discoveredPeripherals[deviceId]?.service?.advertisedUUID?:"").uppercase()))
 
             didConnectPeripheral.discoverServices(null) //services)
         }
@@ -147,15 +149,20 @@ actual class BleManager(
                 centralManager?.cancelPeripheralConnection(peripheral)
                 return
             }
-            val discoveredDevice = discoveredPeripherals[peripheral.identifier.UUIDString]
-            NSLog("BleManager: device service =${peripheral.services} and service on scan discover was ${discoveredDevice?.service?.discoveryServiceUUID}")
-            val targetServiceUuid = discoveredDevice?.service?.discoveryServiceUUID?.let { CBUUID.UUIDWithString(it) }
-            val service = if (targetServiceUuid == null) null else peripheral.services?.firstOrNull {
-                (it as? CBService)?.UUID == targetServiceUuid
-            } as? CBService
+            val discoveredDevice = discoveredPeripherals[peripheral.hash.toString()]
+            NSLog("BleManager: device service =${peripheral.services} and service on scan discover was ${discoveredDevice?.service?.advertisedUUID}")
+            val targetServiceUuid = discoveredDevice?.service?.advertisedUUID?.let { CBUUID.UUIDWithString(it) }
+            NSLog("discover device services=${peripheral.services} targetuuid=${targetServiceUuid}")
+            var service:CBService? =null ;
+            if (targetServiceUuid == null) null else peripheral.services?.forEach {  it ->
+                NSLog(" testing service  = $it against ${discoveredDevice.service.discoveryServiceUUID}")
+                if ((it as? CBService)?.UUID.toString() == discoveredDevice.service.discoveryServiceUUID) {
+                    service = (it as? CBService)
+                }
+            }
 
             if (service == null) {
-                NSLog("BleManager: UWB service not found on ${peripheral.identifier.UUIDString}")
+                NSLog("BleManager: UWB service not found on ${peripheral.hash.toString()}")
                 centralManager?.cancelPeripheralConnection(peripheral)
                 return
             }
@@ -177,7 +184,7 @@ actual class BleManager(
                 centralManager?.cancelPeripheralConnection(peripheral)
                 return
             }
-            val discovererDevice = discoveredPeripherals[peripheral.identifier.UUIDString]
+            val discovererDevice = discoveredPeripherals[peripheral.hash.toString()]
             // Step 1: Read the peer's config
             var readChar:  CBCharacteristic? = null
 
@@ -217,7 +224,7 @@ actual class BleManager(
                 centralManager?.cancelPeripheralConnection(peripheral)
                 return
             }
-            val peerId = peripheral.identifier.UUIDString
+            val peerId = peripheral.hash.toString()
             val discovererDevice = discoveredPeripherals[peerId]
             NSLog("update characteristic = ${didUpdateValueForCharacteristic.UUID}")
             if (didUpdateValueForCharacteristic.UUID == discovererDevice?.service?.readFromUUID?.let { CBUUID.UUIDWithString(it) }){
@@ -248,7 +255,7 @@ actual class BleManager(
                     if (writeChar != null) {
                         val configData = localCfg.toByteArray().toNSData()
                         peripheral.writeValue(configData, writeChar, CBCharacteristicWriteWithoutResponse)
-                        NSLog("BleManager: Wrote config to ${peripheral.identifier.UUIDString}")
+                        NSLog("BleManager: Wrote config to ${peripheral.hash.toString()}")
                     }
                 }
                 // Exchange complete, disconnect
@@ -302,12 +309,16 @@ actual class BleManager(
             if (error != null) {
                 NSLog("BleManager: Failed to add service: ${error.localizedDescription}")
             } else {
-                NSLog("BleManager: GATT service added")
+                var device = discoveredPeripherals[peripheral.hash.toString()]
                 // addService is async — chain the next profile only after this one is added.
                 config.profiles.forEachIndexed { index, service ->
-                    if( didAddService.UUID == CBUUID.UUIDWithString(service.discoveryServiceUUID) ){
-                        if(index < config.profiles.lastIndex)
-                            addGattService(index+1 )
+                    if(service.advertisedUUID == device?.service?.advertisedUUID) {
+                        NSLog("BleManager: GATT service added previously added=${didAddService.UUID} checking=${service.discoveryServiceUUID}")
+                        if (didAddService.UUID == CBUUID.UUIDWithString(service.discoveryServiceUUID)) {
+                            if (index < config.profiles.size - 1)
+                                NSLog("BleManager: GATT service added index=$index last=${config.profiles.size}")
+                            addGattService(config.profiles[index + 1])
+                        }
                     }
                 }
             }
@@ -355,7 +366,7 @@ actual class BleManager(
                     if (data != null) {
                         val remoteConfig = UwbSessionConfig.fromByteArray(data.toByteArray())
                         if (remoteConfig != null) {
-                            val peerId = request.central.identifier.UUIDString
+                            val peerId = request.central.hash.toString()
                             NSLog("BleManager: Received config via GATT write from $peerId")
                             configExchangedCallback?.invoke(peerId, remoteConfig)
                         } else {
@@ -381,7 +392,7 @@ actual class BleManager(
         if (central.state == CBManagerStatePoweredOn) {
             val services: MutableList<CBUUID> = mutableListOf()
             config.profiles.forEach { set ->
-                services.add(CBUUID.UUIDWithString(set.discoveryServiceUUID))
+                set.advertisedUUID?.let { services.add(CBUUID.UUIDWithString(it)) }
             }
             val options = mapOf<Any?, Any?>(
                 CBCentralManagerScanOptionAllowDuplicatesKey to NSNumber(false)
@@ -458,7 +469,11 @@ actual class BleManager(
     /** Adds the first profile's service; the rest are chained via the didAddService delegate. */
     private fun addAllGattServices() {
         if (config.profiles.isNotEmpty()) {
-            addGattService(0)
+            config.profiles.forEach { set ->
+                if(set.advertisedUUID == null)
+                    set.advertisedUUID = set.discoveryServiceUUID
+            }
+            addGattService(config.profiles[0])
         }
     }
 

--- a/uwbmodule/src/iosMain/kotlin/BleManager.kt
+++ b/uwbmodule/src/iosMain/kotlin/BleManager.kt
@@ -103,9 +103,8 @@ actual class BleManager(
                 // Match advertised service UUIDs against our profiles. CBUUID equality normalizes
                 // 16-bit (e.g. FFF0) vs full 128-bit base UUIDs, so no string slicing is needed.
                 config.profiles.forEach { set ->
-                    //val target = CBUUID.UUIDWithString(set.discoveryServiceUUID)
-                    if (serviceUuids.any { it.UUIDString() == set.discoveryServiceUUID  || it.UUIDString() == set.discoveryServiceUUID.slice(IntRange(4,7))  }) {
-                        NSLog("BleManager: found set=${set.discoveryServiceUUID}")
+                    val target = CBUUID.UUIDWithString(set.discoveryServiceUUID)
+                    if (serviceUuids.any { it == target }) {
                         service = set
                     }
                 }

--- a/uwbmodule/src/iosMain/kotlin/BleManager.kt
+++ b/uwbmodule/src/iosMain/kotlin/BleManager.kt
@@ -103,8 +103,8 @@ actual class BleManager(
                 // Match advertised service UUIDs against our profiles. CBUUID equality normalizes
                 // 16-bit (e.g. FFF0) vs full 128-bit base UUIDs, so no string slicing is needed.
                 config.profiles.forEach { set ->
-                    val target = CBUUID.UUIDWithString(set.discoveryServiceUUID)
-                    if (serviceUuids.any { it == target }) {
+                    //val target = CBUUID.UUIDWithString(set.discoveryServiceUUID)
+                    if (serviceUuids.any { it.UUIDString() == set.discoveryServiceUUID  || it.UUIDString() == set.discoveryServiceUUID.slice(IntRange(4,7))  }) {
                         NSLog("BleManager: found set=${set.discoveryServiceUUID}")
                         service = set
                     }


### PR DESCRIPTION
on iOS I changed the discoveredDevices hash to use the peripheral hash as string... this is available in the discovered services callback, where the identifier is not..

as the advertisedUUID is optional, i copy if from the discoveredUUID when the profile entry doesn't have it specified..
then the rest of the code uses the advertised field

note the profile in GattUuids is all the defined 
discover and connect to anything.. 

this branch has base and short_uuid  fixes too..

see #21 