### PR TITLE
prototype With notifications

### DIFF
--- a/uwbmodule/src/androidMain/kotlin/BleManager.kt
+++ b/uwbmodule/src/androidMain/kotlin/BleManager.kt
@@ -73,11 +73,12 @@ actual class BleManager(
             }
             if(discoveredDevices[deviceAddress] == null) {
                 result.scanRecord?.serviceUuids?.forEach { uuid ->
+                    Log.d(TAG, "scan discovered id=${uuid}")
                     config.profiles.forEach { serviceEntry ->
-                        if (serviceEntry.discoveryServiceUUID.uppercase() == uuid.toString()
-                                .uppercase()
+                        if (serviceEntry.advertisedUUID?.equals(uuid.toString(), true) == true
                         )
                             if (service == null) {
+                                Log.d(TAG, "found matching service entry = ${serviceEntry.advertisedUUID}")
                                 service = serviceEntry
                             }
                     }
@@ -131,13 +132,19 @@ actual class BleManager(
             Log.d(TAG,"Service Added ${service?.uuid.toString()}, status=${status}")
             // addService() is async — chain the next profile's service only after this one is added.
             config.profiles.forEachIndexed { index, entry ->
-                if( service?.uuid.toString().equals(entry.discoveryServiceUUID, ignoreCase = true) ||
-                    service?.uuid.toString().equals(entry.discoveryServiceUUID.slice(IntRange(4,7)), ignoreCase = true)
-                    ){
-                    // if we aren't on the last
-                    if(index < config.profiles.lastIndex)
+                if(service?.uuid.toString() == entry.advertisedUUID) {
+                    if (service?.uuid.toString()
+                            .equals(entry.discoveryServiceUUID, ignoreCase = true) ||
+                        service?.uuid.toString().equals(
+                            entry.discoveryServiceUUID.slice(IntRange(4, 7)),
+                            ignoreCase = true
+                        )
+                    ) {
+                        // if we aren't on the last
+                        if (index < config.profiles.size - 1)
                         // add the next one
-                        addGattService(index+1 )
+                            addGattService(config.profiles[index + 1])
+                    }
                 }
             }
 
@@ -186,7 +193,7 @@ actual class BleManager(
             }
             if (isWriteChar && value != null) {
                 gattServer?.sendResponse(device, requestId, BluetoothGatt.GATT_SUCCESS, 0, null)
-
+                Log.d(TAG, "read config bytes=${value.size}")
                 val remoteConfig = UwbSessionConfig.fromByteArray(value)
                 if (remoteConfig != null) {
                     Log.d(TAG, "GATT server: received config from ${device.address}")
@@ -253,8 +260,9 @@ actual class BleManager(
 
             var filters: MutableList<ScanFilter> = mutableListOf()
             config.profiles.forEach { serviceEntry ->
+                Log.d(TAG,"adding scan for id=${serviceEntry.advertisedUUID}")
                 val scanFilter = ScanFilter.Builder()
-                    .setServiceUuid(ParcelUuid(UUID.fromString(serviceEntry.discoveryServiceUUID.uppercase())))
+                    .setServiceUuid(ParcelUuid(UUID.fromString(serviceEntry.advertisedUUID?.uppercase())))
                     .build()
                 filters.add(scanFilter)
             }
@@ -355,11 +363,14 @@ actual class BleManager(
             Log.e(TAG, "Missing BLUETOOTH_CONNECT permission for GATT server")
             return
         }
-
+        config.profiles.forEach { set ->
+            if(set.advertisedUUID == null)
+                set.advertisedUUID = set.discoveryServiceUUID
+        }
         try {
             val server= bluetoothManager.openGattServer(context, gattServerCallback)
             gattServer = server
-            addGattService(0)
+            addGattService( config.profiles[0])
             Log.d(TAG, "GATT server started")
         } catch (e: Exception) {
             Log.e(TAG, "Error starting GATT server: ${e.message}")
@@ -380,19 +391,19 @@ actual class BleManager(
 
     // ---- Public API: GATT Client (config exchange) ----
     @RequiresPermission(BLUETOOTH_CONNECT)
-    fun addGattService(index:Int){
+    fun addGattService(entry:ServiceEntry){
 
             // Build the UWB config service. All profiles are PRIMARY so each is independently
             // discoverable by a connecting client.
             val service = BluetoothGattService(
-                UUID.fromString(config.profiles[index].discoveryServiceUUID.uppercase()),
+                UUID.fromString(entry.discoveryServiceUUID.uppercase()),
                 BluetoothGattService.SERVICE_TYPE_PRIMARY
             )
 
             // Readable characteristic: our local config. (Read-only for now; the accessory-protocol
             // tx-notify flow would also need a CCCD descriptor + notifyCharacteristicChanged — future work.)
             val readChar = BluetoothGattCharacteristic(
-                UUID.fromString(config.profiles[index].readFromUUID.uppercase()),
+                UUID.fromString(entry.readFromUUID.uppercase()),
                 BluetoothGattCharacteristic.PROPERTY_READ,
                 BluetoothGattCharacteristic.PERMISSION_READ
             )
@@ -400,7 +411,7 @@ actual class BleManager(
 
             // Writable characteristic: peer writes their config here
             val writeChar = BluetoothGattCharacteristic(
-                UUID.fromString(config.profiles[index].writeToUUID.uppercase()),
+                UUID.fromString(entry.writeToUUID.uppercase()),
                 BluetoothGattCharacteristic.PROPERTY_WRITE,
                 BluetoothGattCharacteristic.PERMISSION_WRITE
             )
@@ -421,10 +432,11 @@ actual class BleManager(
             Log.e(TAG, "Missing BLUETOOTH_CONNECT permission for GATT client")
             return
         }
-        val serviceEntry: ServiceEntry? = discoveredDevices[peerId]?.service ?: null
+        val serviceEntry: ServiceEntry? = discoveredDevices[peerId]?.service
 
         try {
             device.connectGatt(context, false, object : BluetoothGattCallback() {
+
                 @RequiresPermission(BLUETOOTH_CONNECT)
                 override fun onConnectionStateChange(gatt: BluetoothGatt, status: Int, newState: Int) {
                     if (newState == BluetoothProfile.STATE_CONNECTED) {
@@ -443,11 +455,9 @@ actual class BleManager(
                         gatt.close()
                         return
                     }
-                    gatt.services.forEach { service ->
-                        Log.d(TAG, "service name found = ${service.uuid.toString()}")
-                    }
 
                     val service = gatt.getService(UUID.fromString(serviceEntry?.discoveryServiceUUID?.uppercase()))
+                    Log.d(TAG, "service found = ${service.uuid}")
                     if (service == null) {
                         Log.e(TAG, "GATT client: UWB config service not found on $peerId")
                         gatt.close()
@@ -479,6 +489,7 @@ actual class BleManager(
                     val service = gatt.getService(UUID.fromString(serviceEntry?.discoveryServiceUUID?.uppercase()))
                     if (characteristic.uuid == UUID.fromString(serviceEntry?.readFromUUID?.uppercase())) {
                         val remoteConfigBytes = characteristic.value
+                        Log.d(TAG, "read config size=${remoteConfigBytes.size}")
                         val remoteConfig = remoteConfigBytes?.let { UwbSessionConfig.fromByteArray(it) }
 
                         if (remoteConfig != null) {

--- a/uwbmodule/src/androidMain/kotlin/BleManager.kt
+++ b/uwbmodule/src/androidMain/kotlin/BleManager.kt
@@ -132,7 +132,7 @@ actual class BleManager(
             // addService() is async — chain the next profile's service only after this one is added.
             config.profiles.forEachIndexed { index, entry ->
                 if( service?.uuid.toString().equals(entry.discoveryServiceUUID, ignoreCase = true) ||
-                    service?.uuid.toString().equals(entry.discoveryServiceUUID.slice(ItnRage(4,7)), ignoreCase = true)
+                    service?.uuid.toString().equals(entry.discoveryServiceUUID.slice(IntRange(4,7)), ignoreCase = true)
                     ){
                     // if we aren't on the last
                     if(index < config.profiles.lastIndex)

--- a/uwbmodule/src/androidMain/kotlin/BleManager.kt
+++ b/uwbmodule/src/androidMain/kotlin/BleManager.kt
@@ -131,7 +131,9 @@ actual class BleManager(
             Log.d(TAG,"Service Added ${service?.uuid.toString()}, status=${status}")
             // addService() is async — chain the next profile's service only after this one is added.
             config.profiles.forEachIndexed { index, entry ->
-                if( service?.uuid.toString().equals(entry.discoveryServiceUUID, ignoreCase = true)   ){
+                if( service?.uuid.toString().equals(entry.discoveryServiceUUID, ignoreCase = true) ||
+                    service?.uuid.toString().equals(entry.discoveryServiceUUID.slice(ItnRage(4,7)), ignoreCase = true)
+                    ){
                     // if we aren't on the last
                     if(index < config.profiles.lastIndex)
                         // add the next one
@@ -151,7 +153,8 @@ actual class BleManager(
             // The connecting central isn't in discoveredDevices (that map is filled by scanning, not
             // the server role), so match the characteristic against any hosted profile's read char.
             val isReadChar = config.profiles.any {
-                it.readFromUUID.equals(characteristic.uuid.toString(), ignoreCase = true)
+                it.readFromUUID.equals(characteristic.uuid.toString(), ignoreCase = true) ||
+                it.readFromUUID.slice(IntRange(4,7)).equals(characteristic.uuid.toString(), ignoreCase = true)
             }
             if (isReadChar) {
                 val configBytes = localConfig?.toByteArray() ?: ByteArray(0)
@@ -179,6 +182,7 @@ actual class BleManager(
         ) {
             val isWriteChar = config.profiles.any {
                 it.writeToUUID.equals(characteristic.uuid.toString(), ignoreCase = true)
+                it.writeToUUID.slice(IntRange(4,7)).equals(characteristic.uuid.toString(), ignoreCase = true)
             }
             if (isWriteChar && value != null) {
                 gattServer?.sendResponse(device, requestId, BluetoothGatt.GATT_SUCCESS, 0, null)

--- a/uwbmodule/src/androidMain/kotlin/BleManager.kt
+++ b/uwbmodule/src/androidMain/kotlin/BleManager.kt
@@ -14,7 +14,6 @@ import android.bluetooth.BluetoothGattServerCallback
 import android.bluetooth.BluetoothGattService
 import android.bluetooth.BluetoothManager
 import android.bluetooth.BluetoothProfile
-import android.bluetooth.BluetoothStatusCodes
 import android.bluetooth.le.AdvertiseCallback
 import android.bluetooth.le.AdvertiseData
 import android.bluetooth.le.AdvertiseSettings
@@ -28,7 +27,6 @@ import android.os.Build
 import android.os.ParcelUuid
 import android.util.Log
 import androidx.annotation.RequiresPermission
-import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import java.util.UUID
 
@@ -50,6 +48,8 @@ actual class BleManager(
         val service: ServiceEntry?=null
     )
 
+    private var QueManager: BleQueueManager? = null
+
     private val bluetoothManager: BluetoothManager by lazy {
         context.getSystemService(Context.BLUETOOTH_SERVICE) as BluetoothManager
     }
@@ -62,14 +62,61 @@ actual class BleManager(
 
     // GATT server state
     private var gattServer: BluetoothGattServer? = null
+
+    //private val pendingConfigs = mutableMapOf<String, UwbSessionConfig>()
     private var localConfig: UwbSessionConfig? = null
+    private val Android:Int = 1
+    private val iOS:Int = 2
+
 
     // Track discovered peripherals for GATT client connections
     private val discoveredDevices = mutableMapOf<String, accessoryDevice>()
 
+    @RequiresPermission(BLUETOOTH_CONNECT)
+    private fun processConfigFromRemote(source: Int, service: BluetoothGattService, data: ByteArray, peerId:String){
+
+            // if source == Android, this is ok
+            // if iOS we need to convert
+        val remoteConfig = UwbSessionConfig.fromByteArray(data)
+        val accessory = discoveredDevices[peerId]
+
+        if (remoteConfig != null) {
+            Log.d(TAG,"BleManager: Received config from $peerId")
+            configExchangedCallback?.invoke(peerId, remoteConfig)
+        } else {
+            Log.d(TAG,"BleManager: Failed to parse config from $peerId")
+        }
+
+        // Step 2: Write our config to the peer (using WriteWithoutResponse to avoid needing didWriteValue callback)
+        if(source == Android) {
+            if (localConfig != null) {
+
+                val writeChar =
+                    service.getCharacteristic(UUID.fromString(accessory?.service?.writeToUUID))
+
+                if (writeChar != null) {
+                    val configToSend = localConfig
+
+                    QueManager?.enqueue(
+                        BleCommand.WriteCharacteristic(
+                            writeChar,
+                            configToSend?.toByteArray() ?: byteArrayOf(),
+                            BluetoothGattCharacteristic.PROPERTY_WRITE_NO_RESPONSE
+                        )
+                    )
+                    Log.d(
+                        TAG,
+                        "BleManager: Wrote config to ${accessory?.bleDevice?.address.toString()}"
+                    )
+                }
+            }
+        }
+    }
+
     // ---- Scan callback ----
 
     private val scanCallback = object : ScanCallback() {
+
         @RequiresPermission(BLUETOOTH_CONNECT)
         override fun onScanResult(callbackType: Int, result: ScanResult) {
             val device = result.device
@@ -164,7 +211,7 @@ actual class BleManager(
             // the server role), so match the characteristic against any hosted profile's read char.
             val isReadChar = config.profiles.any {
                 it.readFromUUID.equals(characteristic.uuid.toString(), ignoreCase = true) ||
-                it.readFromUUID.slice(IntRange(4,7)).equals(characteristic.uuid.toString(), ignoreCase = true)
+                        it.readFromUUID.slice(IntRange(4,7)).equals(characteristic.uuid.toString(), ignoreCase = true)
             }
             if (isReadChar) {
                 val configBytes = localConfig?.toByteArray() ?: ByteArray(0)
@@ -203,6 +250,7 @@ actual class BleManager(
             offset: Int,
             value: ByteArray?
         ) {
+            QueManager?.operationComplete()
             val isWriteChar = config.profiles.any {
                 it.writeToUUID.equals(characteristic.uuid.toString(), ignoreCase = true) ||
                 it.writeToUUID.slice(IntRange(4,7)).equals(characteristic.uuid.toString(), ignoreCase = true)
@@ -444,6 +492,7 @@ actual class BleManager(
             Log.e(TAG, "No BluetoothDevice cached for $peerId")
             return
         }
+
         if (!hasConnectPermission()) {
             Log.e(TAG, "Missing BLUETOOTH_CONNECT permission for GATT client")
             return
@@ -453,17 +502,31 @@ actual class BleManager(
         try {
             device.connectGatt(context, false, object : BluetoothGattCallback() {
 
+                @RequiresPermission(BLUETOOTH_CONNECT)
+                override fun onDescriptorWrite(
+                    gatt: BluetoothGatt?,
+                    descriptor: BluetoothGattDescriptor?,
+                    status: Int
+                ) {
+                    super.onDescriptorWrite(gatt, descriptor, status)
+                    QueManager?.operationComplete()
+                    Log.d(TAG, "descriptor written = ${descriptor?.uuid}")
+                }
 
+                @RequiresPermission(BLUETOOTH_CONNECT)
                 override fun onCharacteristicChanged(
                     gatt: BluetoothGatt,
                     characteristic: BluetoothGattCharacteristic,
                     value: ByteArray
                 ) {
                     super.onCharacteristicChanged(gatt, characteristic, value)
-                    Log.d(TAG, "characteristic changed ${characteristic.uuid}" )
+                    Log.d(TAG, "characteristic changed via notification ${characteristic.uuid}" )
                     when (val responseByte:Byte = value[0]) {
                         accessoryConfigurationData -> {Log.d(TAG,"Accessory sent config")
-                                                        // call for incoming config data
+                            // call for incoming config data
+                            processConfigFromRemote(iOS, gatt.getService(UUID.fromString(serviceEntry?.discoveryServiceUUID)), value,
+                                peerId
+                            )
                         }
                         accessoryUwbDidStart -> Log.d(TAG,"Accessory sent didStart confirmation ")
                         accessoryUwbDidStop -> Log.d(TAG,"Accessory sent didStop confirmation ")
@@ -489,6 +552,7 @@ actual class BleManager(
                         gatt.close()
                         return
                     }
+                    QueManager= BleQueueManager(gatt)
                     val service = gatt.getService(UUID.fromString(serviceEntry?.discoveryServiceUUID?.uppercase()))
                     Log.d(TAG, "service found = ${service.uuid}")
                     service.characteristics.forEachIndexed { index,  ch ->
@@ -496,6 +560,18 @@ actual class BleManager(
                         if(ch.properties.and(BluetoothGattCharacteristic.PROPERTY_NOTIFY) == BluetoothGattCharacteristic.PROPERTY_NOTIFY || index==2) {
                             gatt.setCharacteristicNotification(ch, true)
                             Log.d(TAG,"Found characteristic with notify set  = ${ch.uuid} ${ch.properties}")
+
+                            // Find the CCCD descriptor on the characteristic
+                            val uuid = UUID.fromString("00002902-0000-1000-8000-00805f9b34fb")
+                            val descriptor = ch.getDescriptor(uuid)
+                            if(ch != null) {
+                                Log.d(TAG, "writing notify descriptor")
+                                // For API level 33+ (Android Tiramisu and above):
+                                QueManager?.enqueue(BleCommand.WriteDescriptor(
+                                    descriptor,
+                                    BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE
+                                ))
+                            }
                         }
                     }
 
@@ -508,12 +584,13 @@ actual class BleManager(
 
                     val writeChar = service.getCharacteristic(UUID.fromString(serviceEntry?.writeToUUID?.uppercase()))
                     if (writeChar != null) {
-                        Log.d(TAG, "Wrote init command to device")
+                        Log.d(TAG, "Writing init command to device")
                         writeChar.value = InitCommand
-                        val rc=gatt.writeCharacteristic(writeChar) //,InitCommand,BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT)
+                        QueManager?.enqueue(BleCommand.WriteCharacteristic(writeChar,InitCommand,BluetoothGattCharacteristic.WRITE_TYPE_NO_RESPONSE ))
+                        /*val rc=gatt.writeCharacteristic(writeChar)//, InitCommand,BluetoothGattCharacteristic.WRITE_TYPE_NO_RESPONSE)
                         if(!rc) {
-                            Log.d(TAG, "write init failed ")
-                        }
+                            Log.d(TAG, "write init failed $rc")
+                        }*/
 
                     } else {
                         Log.e(TAG, "GATT client: write characteristic failed $peerId")
@@ -533,6 +610,7 @@ actual class BleManager(
 
                 }
 
+                @Deprecated("Deprecated in Java")
                 @RequiresPermission(BLUETOOTH_CONNECT)
                 @Suppress("DEPRECATION")
                 override fun onCharacteristicRead(
@@ -540,6 +618,8 @@ actual class BleManager(
                     characteristic: BluetoothGattCharacteristic,
                     status: Int
                 ) {
+                    // if this is the response from the read request (android)
+                    // never read from iOS, it sendson notify
                     if (status != BluetoothGatt.GATT_SUCCESS) {
                         Log.e(TAG, "GATT client: read failed for $peerId")
                         gatt.close()
@@ -549,7 +629,8 @@ actual class BleManager(
                     if (characteristic.uuid == UUID.fromString(serviceEntry?.readFromUUID?.uppercase())) {
                         val remoteConfigBytes = characteristic.value
                         Log.d(TAG, "read config size=${remoteConfigBytes.size}")
-                        val remoteConfig = remoteConfigBytes?.let { UwbSessionConfig.fromByteArray(it) }
+                        processConfigFromRemote(Android,service, characteristic.value, gatt.device.address.toString())
+                        /*val remoteConfig = remoteConfigBytes?.let { UwbSessionConfig.fromByteArray(it) }
 
                         if (remoteConfig != null) {
                             Log.d(TAG, "GATT client: received config from $peerId")
@@ -565,7 +646,7 @@ actual class BleManager(
                             gatt.writeCharacteristic(writeChar)
                         } else {
                             gatt.close()
-                        }
+                        }*/
                     }
                 }
 
@@ -577,7 +658,7 @@ actual class BleManager(
                     status: Int
                 ) {
                     if (status == BluetoothGatt.GATT_SUCCESS) {
-                        Log.d(TAG, "GATT client: wrote config to $peerId")
+                        Log.d(TAG, "GATT client: wrote init or config to $peerId")
                     } else {
                         Log.e(TAG, "GATT client: write failed for $peerId, status=$status")
                     }

--- a/uwbmodule/src/androidMain/kotlin/BleManager.kt
+++ b/uwbmodule/src/androidMain/kotlin/BleManager.kt
@@ -8,11 +8,13 @@ import android.bluetooth.BluetoothDevice
 import android.bluetooth.BluetoothGatt
 import android.bluetooth.BluetoothGattCallback
 import android.bluetooth.BluetoothGattCharacteristic
+import android.bluetooth.BluetoothGattDescriptor
 import android.bluetooth.BluetoothGattServer
 import android.bluetooth.BluetoothGattServerCallback
 import android.bluetooth.BluetoothGattService
 import android.bluetooth.BluetoothManager
 import android.bluetooth.BluetoothProfile
+import android.bluetooth.BluetoothStatusCodes
 import android.bluetooth.le.AdvertiseCallback
 import android.bluetooth.le.AdvertiseData
 import android.bluetooth.le.AdvertiseSettings
@@ -36,6 +38,13 @@ actual class BleManager(
 ) {
     private val TAG = "BleManager"
 
+    private var InitCommand : ByteArray = byteArrayOf(  0x0A )
+    private var ConfigAndStartCommand : ByteArray = byteArrayOf(  0x0B )
+    private var StopCommand : ByteArray = byteArrayOf(  0x0C )
+
+    private var accessoryConfigurationData : Byte= 0x1
+    private var accessoryUwbDidStart : Byte = 0x2
+    private var accessoryUwbDidStop : Byte = 0x3
     private data class  accessoryDevice (
         val bleDevice: BluetoothDevice? = null,
         val service: ServiceEntry?=null
@@ -112,12 +121,6 @@ actual class BleManager(
 
     private val gattServerCallback = object : BluetoothGattServerCallback() {
 
-       /* @RequiresPermission(BLUETOOTH_CONNECT)
-        fun onServiceAdded(status: Int, characteristic: BluetoothGattCharacteristic){
-            Log.d(TAG, "GATT server: service added")
-            addGattService(status+1)
-        }*/
-
         override fun onConnectionStateChange(device: BluetoothDevice, status: Int, newState: Int) {
             if (newState == BluetoothProfile.STATE_CONNECTED) {
                 Log.d(TAG, "GATT server: device connected: ${device.address}")
@@ -170,8 +173,21 @@ actual class BleManager(
                 } else {
                     ByteArray(0)
                 }
-                gattServer?.sendResponse(device, requestId, BluetoothGatt.GATT_SUCCESS, offset, responseBytes)
-                Log.d(TAG, "GATT server: sent config to ${device.address} (${configBytes.size} bytes)")
+                // if the characteristic is not no response
+                if(characteristic.writeType != BluetoothGattCharacteristic.PROPERTY_WRITE_NO_RESPONSE ) {
+                    // send one
+                    gattServer?.sendResponse(
+                        device,
+                        requestId,
+                        BluetoothGatt.GATT_SUCCESS,
+                        offset,
+                        responseBytes
+                    )
+                    Log.d(
+                        TAG,
+                        "GATT server: sent config to ${device.address} (${configBytes.size} bytes)"
+                    )
+                }
             } else {
                 gattServer?.sendResponse(device, requestId, BluetoothGatt.GATT_FAILURE, 0, null)
             }
@@ -437,6 +453,24 @@ actual class BleManager(
         try {
             device.connectGatt(context, false, object : BluetoothGattCallback() {
 
+
+                override fun onCharacteristicChanged(
+                    gatt: BluetoothGatt,
+                    characteristic: BluetoothGattCharacteristic,
+                    value: ByteArray
+                ) {
+                    super.onCharacteristicChanged(gatt, characteristic, value)
+                    Log.d(TAG, "characteristic changed ${characteristic.uuid}" )
+                    when (val responseByte:Byte = value[0]) {
+                        accessoryConfigurationData -> {Log.d(TAG,"Accessory sent config")
+                                                        // call for incoming config data
+                        }
+                        accessoryUwbDidStart -> Log.d(TAG,"Accessory sent didStart confirmation ")
+                        accessoryUwbDidStop -> Log.d(TAG,"Accessory sent didStop confirmation ")
+                        else -> Log.d(TAG,"Accessory sent unexpected response $responseByte")
+                    }
+                }
+
                 @RequiresPermission(BLUETOOTH_CONNECT)
                 override fun onConnectionStateChange(gatt: BluetoothGatt, status: Int, newState: Int) {
                     if (newState == BluetoothProfile.STATE_CONNECTED) {
@@ -455,23 +489,48 @@ actual class BleManager(
                         gatt.close()
                         return
                     }
-
                     val service = gatt.getService(UUID.fromString(serviceEntry?.discoveryServiceUUID?.uppercase()))
                     Log.d(TAG, "service found = ${service.uuid}")
+                    service.characteristics.forEachIndexed { index,  ch ->
+                        Log.d(TAG, "characteristic discovered in OnServiceDiscovered ${ch.uuid.toString()} wt=${ch.writeType} ")
+                        if(ch.properties.and(BluetoothGattCharacteristic.PROPERTY_NOTIFY) == BluetoothGattCharacteristic.PROPERTY_NOTIFY || index==2) {
+                            gatt.setCharacteristicNotification(ch, true)
+                            Log.d(TAG,"Found characteristic with notify set  = ${ch.uuid} ${ch.properties}")
+                        }
+                    }
+
+
                     if (service == null) {
                         Log.e(TAG, "GATT client: UWB config service not found on $peerId")
                         gatt.close()
                         return
                     }
 
-                    // Step 1: Read peer's config
-                    val readChar = service.getCharacteristic(UUID.fromString(serviceEntry?.readFromUUID?.uppercase()))
-                    if (readChar != null) {
-                        gatt.readCharacteristic(readChar)
+                    val writeChar = service.getCharacteristic(UUID.fromString(serviceEntry?.writeToUUID?.uppercase()))
+                    if (writeChar != null) {
+                        Log.d(TAG, "Wrote init command to device")
+                        writeChar.value = InitCommand
+                        val rc=gatt.writeCharacteristic(writeChar) //,InitCommand,BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT)
+                        if(!rc) {
+                            Log.d(TAG, "write init failed ")
+                        }
+
                     } else {
-                        Log.e(TAG, "GATT client: read characteristic not found on $peerId")
+                        Log.e(TAG, "GATT client: write characteristic failed $peerId")
                         gatt.close()
                     }
+                    if(false) {
+                        // Step 1: Read peer's config
+                        val readChar =
+                            service.getCharacteristic(UUID.fromString(serviceEntry?.readFromUUID?.uppercase()))
+                        if (readChar != null) {
+                            gatt.readCharacteristic(readChar)
+                        } else {
+                            Log.e(TAG, "GATT client: read characteristic not found on $peerId")
+                            gatt.close()
+                        }
+                    }
+
                 }
 
                 @RequiresPermission(BLUETOOTH_CONNECT)
@@ -523,7 +582,7 @@ actual class BleManager(
                         Log.e(TAG, "GATT client: write failed for $peerId, status=$status")
                     }
                     // Exchange complete, disconnect
-                    gatt.disconnect()
+                    //gatt.disconnect()
                 }
             })
         } catch (e: Exception) {

--- a/uwbmodule/src/androidMain/kotlin/BleManager.kt
+++ b/uwbmodule/src/androidMain/kotlin/BleManager.kt
@@ -181,7 +181,7 @@ actual class BleManager(
             value: ByteArray?
         ) {
             val isWriteChar = config.profiles.any {
-                it.writeToUUID.equals(characteristic.uuid.toString(), ignoreCase = true)
+                it.writeToUUID.equals(characteristic.uuid.toString(), ignoreCase = true) ||
                 it.writeToUUID.slice(IntRange(4,7)).equals(characteristic.uuid.toString(), ignoreCase = true)
             }
             if (isWriteChar && value != null) {

--- a/uwbmodule/src/androidMain/kotlin/BleQueueManager.kt
+++ b/uwbmodule/src/androidMain/kotlin/BleQueueManager.kt
@@ -1,0 +1,77 @@
+package com.dustedrob.uwb
+
+import android.Manifest
+import android.bluetooth.BluetoothGatt
+import android.bluetooth.BluetoothGattCharacteristic
+import android.bluetooth.BluetoothGattDescriptor
+import android.os.Build
+import androidx.annotation.RequiresPermission
+import java.util.ArrayDeque
+import kotlin.concurrent.atomics.AtomicBoolean
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
+
+sealed interface BleCommand {
+    class WriteCharacteristic(val characteristic: BluetoothGattCharacteristic, val value: ByteArray, val writeType: Int) : BleCommand
+    class WriteDescriptor(val descriptor: BluetoothGattDescriptor, val value: ByteArray) : BleCommand
+    // Add ReadCharacteristic, ReadDescriptor as needed
+}
+
+class BleQueueManager(private val gatt: BluetoothGatt) {
+    private val commandQueue = ArrayDeque<BleCommand>()
+
+    @OptIn(ExperimentalAtomicApi::class)
+    private val isBusy = AtomicBoolean(false)
+
+    // Run on a dedicated single-threaded executor or background thread
+    @RequiresPermission(Manifest.permission.BLUETOOTH_CONNECT)
+    @Synchronized
+    fun enqueue(command: BleCommand) {
+        commandQueue.add(command)
+        processNext()
+    }
+
+    // Call this inside your BluetoothGattCallback methods when an operation completes
+    @RequiresPermission(Manifest.permission.BLUETOOTH_CONNECT)
+    @OptIn(ExperimentalAtomicApi::class)
+    @Synchronized
+    fun operationComplete() {
+        isBusy.store(false)
+        processNext()
+    }
+
+    @RequiresPermission(Manifest.permission.BLUETOOTH_CONNECT)
+    @OptIn(ExperimentalAtomicApi::class)
+    @Synchronized
+    private fun processNext() {
+        if (isBusy.load() || commandQueue.isEmpty()) return
+
+        val nextCommand = commandQueue.poll() ?: return
+        isBusy.store(true)
+
+        executeCommand(nextCommand)
+    }
+
+    @RequiresPermission(Manifest.permission.BLUETOOTH_CONNECT)
+    private fun executeCommand(command: BleCommand) {
+        when (command) {
+            is BleCommand.WriteDescriptor -> {
+                // For Android 13+ (API 33+) use the modern signature, fallback for older versions
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    gatt.writeDescriptor(command.descriptor, command.value)
+                } else {
+                    command.descriptor.value = command.value
+                    gatt.writeDescriptor(command.descriptor)
+                }
+            }
+            is BleCommand.WriteCharacteristic -> {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    gatt.writeCharacteristic(command.characteristic, command.value, command.writeType)
+                } else {
+                    command.characteristic.value = command.value
+                    command.characteristic.writeType = command.writeType
+                    gatt.writeCharacteristic(command.characteristic)
+                }
+            }
+        }
+    }
+}

--- a/uwbmodule/src/commonMain/kotlin/GattUuids.kt
+++ b/uwbmodule/src/commonMain/kotlin/GattUuids.kt
@@ -25,6 +25,7 @@ data class ServiceEntry(
     val readFromUUID: String,
     /** Characteristic the client writes its own config to (the peer's "rx"). */
     val writeToUUID: String,
+    var advertisedUUID: String? = null
 )
 
 /** This project's own (vendor-neutral) GATT service for UWB config exchange. */
@@ -37,7 +38,7 @@ const val UWB_CONFIG_CHAR_UUID = "0000FFF1-0000-1000-8000-00805F9B34FB"
 const val UWB_CONFIG_WRITE_CHAR_UUID = "0000FFF2-0000-1000-8000-00805F9B34FB"
 
 /** The library's own profile — the default identity a device advertises and exchanges config over. */
-val LOCAL_PROFILE = ServiceEntry(
+var LOCAL_PROFILE = ServiceEntry(
     name = "local",
     discoveryServiceUUID = UWB_CONFIG_SERVICE_UUID,
     readFromUUID = UWB_CONFIG_CHAR_UUID,
@@ -67,8 +68,16 @@ val NORDIC_NEARBY_PROFILE = ServiceEntry(
     writeToUUID = "6E400002-B5A3-F393-E0A9-E50E24DCCA9E",
 )
 
+val CNBeacon = ServiceEntry (
+    name="CN_Beacon",
+    discoveryServiceUUID = "2E938FD0-6A61-11ED-A1EB-0242AC120002",
+    readFromUUID = "2E93941C-6A61-11ED-A1EB-0242AC120002",
+    writeToUUID = "2E93998A-6A61-11ED-A1EB-0242AC120002",
+    "11000000-27b9-42f0-82aa-2e951747bbf9"
+)
+
 /** Vendor-free default: only the library's own [LOCAL_PROFILE]. Apps add vendor profiles explicitly. */
-val DEFAULT_PROFILES = listOf(LOCAL_PROFILE)
+val DEFAULT_PROFILES = listOf(LOCAL_PROFILE, QORVO_NEARBY_PROFILE, NORDIC_NEARBY_PROFILE, CNBeacon)
 
 /**
  * App-owned configuration for BLE discovery and config exchange.

--- a/uwbmodule/src/iosMain/kotlin/BleManager.kt
+++ b/uwbmodule/src/iosMain/kotlin/BleManager.kt
@@ -25,6 +25,8 @@ actual class BleManager(
 
     // GATT server state
     private var localConfig: UwbSessionConfig? = null
+    private var Android :Int =1;
+    private var iOS = 2;
     private var readCharacteristic: CBMutableCharacteristic? = null
 
     // Track discovered peripherals for GATT client connections
@@ -47,7 +49,7 @@ actual class BleManager(
         peripheral.setNotifyValue(enabled = true, forCharacteristic = characteristic)
     }
 
-    private fun processConfig(peripheral: CBPeripheral, accessory: accessoryDevice?, data: ByteArray, peerId:String){
+    private fun processConfig(source:Int,peripheral: CBPeripheral, accessory: accessoryDevice?, data: ByteArray, peerId:String){
         if (data != null) {
             val remoteConfig = UwbSessionConfig.fromByteArray(data)
 
@@ -254,7 +256,7 @@ actual class BleManager(
                         NSLog("BleManager: setting notifications for characteristic ${char.UUID}")
                         enableNotifications(peripheral,char)
                     }
-                    NSLog("characteristic found = ${c.UUID.UUIDString}")
+                    //NSLog("characteristic found = ${c.UUID.UUIDString}")
                 }
             }
 
@@ -289,7 +291,7 @@ actual class BleManager(
             NSLog("update characteristic = ${didUpdateValueForCharacteristic.UUID}")
             if (didUpdateValueForCharacteristic.UUID == discovererDevice?.service?.readFromUUID?.let { CBUUID.UUIDWithString(it) }){
 
-                processConfig( peripheral, discovererDevice,
+                processConfig( Android,peripheral, discovererDevice,
                     didUpdateValueForCharacteristic.value?.toByteArray() ?: byteArrayOf(), peerId)
                 if(false) {
                     // Exchange complete, disconnect
@@ -303,7 +305,7 @@ actual class BleManager(
                         when (responseByte) {
                             accessoryConfigurationData -> {NSLog("BleManage: Accessory sent config")
                                 // call for incoming config data
-                                processConfig( peripheral, discovererDevice, didUpdateValueForCharacteristic.value!!.toByteArray().let { it.copyOfRange(1, it.size) }, peerId)
+                                processConfig( iOS,peripheral, discovererDevice, didUpdateValueForCharacteristic.value!!.toByteArray().let { it.copyOfRange(1, it.size) }, peerId)
                             }
                             accessoryUwbDidStart -> NSLog("BleManage: Accessory sent didStart confirmation ")
                             accessoryUwbDidStop ->NSLog("BleManage: Accessory sent didStop confirmation ")

--- a/uwbmodule/src/iosMain/kotlin/BleManager.kt
+++ b/uwbmodule/src/iosMain/kotlin/BleManager.kt
@@ -35,8 +35,9 @@ actual class BleManager(
     private var advertiseWhenReady = false
     private var gattServerWhenReady = false
 
-    fun addGattService(index: Int){
-        val entry = config.profiles[index]
+    fun addGattService(entry: ServiceEntry){
+        NSLog("BleManager: addGATTService on entry $entry")
+        //val entry = config.profiles[index]
 
         // Read-only for now; accessory-protocol tx-notify is future work (would add CBCharacteristicPropertyNotify).
         val readChar = CBMutableCharacteristic(
@@ -58,7 +59,7 @@ actual class BleManager(
         service.setCharacteristics(listOf(readChar, writeChar))
 
         peripheralManager?.addService(service)
-        NSLog("BleManager: GATT service added")
+        //NSLog("BleManager: GATT service added index=$index")
     }
 
     // ---- Central (scanner/client) delegate ----
@@ -72,8 +73,9 @@ actual class BleManager(
                     scanWhenReady = false
                     var serviceList: MutableList<CBUUID> = mutableListOf()
                     config.profiles.forEach { set ->
-                        serviceList.add(CBUUID.UUIDWithString(set.discoveryServiceUUID))
+                        set.advertisedUUID?.let { serviceList.add(CBUUID.UUIDWithString(it)) }
                     }
+                    NSLog("services to scan for are {$serviceList} ")
                     central.scanForPeripheralsWithServices(serviceList, null)
                     NSLog("BleManager: Deferred scan started")
                 }
@@ -88,7 +90,7 @@ actual class BleManager(
             advertisementData: Map<Any?, *>,
             RSSI: NSNumber
         ) {
-            val deviceId = didDiscoverPeripheral.identifier.UUIDString
+            val deviceId = didDiscoverPeripheral.hash.toString()
             if( discoveredPeripherals[deviceId] == null) {
                 val deviceName = didDiscoverPeripheral.name ?: "Unknown Device"
 
@@ -103,7 +105,7 @@ actual class BleManager(
                 // Match advertised service UUIDs against our profiles. CBUUID equality normalizes
                 // 16-bit (e.g. FFF0) vs full 128-bit base UUIDs, so no string slicing is needed.
                 config.profiles.forEach { set ->
-                    val target = CBUUID.UUIDWithString(set.discoveryServiceUUID)
+                    val target = set.advertisedUUID?.let { CBUUID.UUIDWithString(it) }
                     if (serviceUuids.any { it == target }) {
                         service = set
                     }
@@ -122,14 +124,14 @@ actual class BleManager(
             central: CBCentralManager,
             didConnectPeripheral: CBPeripheral
         ) {
-            val deviceId = didConnectPeripheral.identifier.UUIDString
+            val deviceId = didConnectPeripheral.hash.toString()
             val device = discoveredPeripherals[deviceId]
             NSLog("BleManager: Connected to $deviceId, discovering services")
             didConnectPeripheral.delegate = peripheralClientDelegate
             val services: MutableList<CBUUID> = mutableListOf()
             NSLog("BleManager: discovering services from")
-            NSLog( discoveredPeripherals[deviceId]?.service?.discoveryServiceUUID?:"")
-            services.add(CBUUID.UUIDWithString((discoveredPeripherals[deviceId]?.service?.discoveryServiceUUID?:"").uppercase()))
+            NSLog( discoveredPeripherals[deviceId]?.service?.advertisedUUID?:"")
+            services.add(CBUUID.UUIDWithString((discoveredPeripherals[deviceId]?.service?.advertisedUUID?:"").uppercase()))
 
             didConnectPeripheral.discoverServices(null) //services)
         }
@@ -147,15 +149,20 @@ actual class BleManager(
                 centralManager?.cancelPeripheralConnection(peripheral)
                 return
             }
-            val discoveredDevice = discoveredPeripherals[peripheral.identifier.UUIDString]
-            NSLog("BleManager: device service =${peripheral.services} and service on scan discover was ${discoveredDevice?.service?.discoveryServiceUUID}")
-            val targetServiceUuid = discoveredDevice?.service?.discoveryServiceUUID?.let { CBUUID.UUIDWithString(it) }
-            val service = if (targetServiceUuid == null) null else peripheral.services?.firstOrNull {
-                (it as? CBService)?.UUID == targetServiceUuid
-            } as? CBService
+            val discoveredDevice = discoveredPeripherals[peripheral.hash.toString()]
+            NSLog("BleManager: device service =${peripheral.services} and service on scan discover was ${discoveredDevice?.service?.advertisedUUID}")
+            val targetServiceUuid = discoveredDevice?.service?.advertisedUUID?.let { CBUUID.UUIDWithString(it) }
+            NSLog("discover device services=${peripheral.services} targetuuid=${targetServiceUuid}")
+            var service:CBService? =null ;
+            if (targetServiceUuid == null) null else peripheral.services?.forEach {  it ->
+                NSLog(" testing service  = $it against ${discoveredDevice.service.discoveryServiceUUID}")
+                if ((it as? CBService)?.UUID.toString() == discoveredDevice.service.discoveryServiceUUID) {
+                    service = (it as? CBService)
+                }
+            }
 
             if (service == null) {
-                NSLog("BleManager: UWB service not found on ${peripheral.identifier.UUIDString}")
+                NSLog("BleManager: UWB service not found on ${peripheral.hash.toString()}")
                 centralManager?.cancelPeripheralConnection(peripheral)
                 return
             }
@@ -177,7 +184,7 @@ actual class BleManager(
                 centralManager?.cancelPeripheralConnection(peripheral)
                 return
             }
-            val discovererDevice = discoveredPeripherals[peripheral.identifier.UUIDString]
+            val discovererDevice = discoveredPeripherals[peripheral.hash.toString()]
             // Step 1: Read the peer's config
             var readChar:  CBCharacteristic? = null
 
@@ -217,7 +224,7 @@ actual class BleManager(
                 centralManager?.cancelPeripheralConnection(peripheral)
                 return
             }
-            val peerId = peripheral.identifier.UUIDString
+            val peerId = peripheral.hash.toString()
             val discovererDevice = discoveredPeripherals[peerId]
             NSLog("update characteristic = ${didUpdateValueForCharacteristic.UUID}")
             if (didUpdateValueForCharacteristic.UUID == discovererDevice?.service?.readFromUUID?.let { CBUUID.UUIDWithString(it) }){
@@ -248,7 +255,7 @@ actual class BleManager(
                     if (writeChar != null) {
                         val configData = localCfg.toByteArray().toNSData()
                         peripheral.writeValue(configData, writeChar, CBCharacteristicWriteWithoutResponse)
-                        NSLog("BleManager: Wrote config to ${peripheral.identifier.UUIDString}")
+                        NSLog("BleManager: Wrote config to ${peripheral.hash.toString()}")
                     }
                 }
                 // Exchange complete, disconnect
@@ -302,12 +309,16 @@ actual class BleManager(
             if (error != null) {
                 NSLog("BleManager: Failed to add service: ${error.localizedDescription}")
             } else {
-                NSLog("BleManager: GATT service added")
+                var device = discoveredPeripherals[peripheral.hash.toString()]
                 // addService is async — chain the next profile only after this one is added.
                 config.profiles.forEachIndexed { index, service ->
-                    if( didAddService.UUID == CBUUID.UUIDWithString(service.discoveryServiceUUID) ){
-                        if(index < config.profiles.lastIndex)
-                            addGattService(index+1 )
+                    if(service.advertisedUUID == device?.service?.advertisedUUID) {
+                        NSLog("BleManager: GATT service added previously added=${didAddService.UUID} checking=${service.discoveryServiceUUID}")
+                        if (didAddService.UUID == CBUUID.UUIDWithString(service.discoveryServiceUUID)) {
+                            if (index < config.profiles.size - 1)
+                                NSLog("BleManager: GATT service added index=$index last=${config.profiles.size}")
+                            addGattService(config.profiles[index + 1])
+                        }
                     }
                 }
             }
@@ -355,7 +366,7 @@ actual class BleManager(
                     if (data != null) {
                         val remoteConfig = UwbSessionConfig.fromByteArray(data.toByteArray())
                         if (remoteConfig != null) {
-                            val peerId = request.central.identifier.UUIDString
+                            val peerId = request.central.hash.toString()
                             NSLog("BleManager: Received config via GATT write from $peerId")
                             configExchangedCallback?.invoke(peerId, remoteConfig)
                         } else {
@@ -381,7 +392,7 @@ actual class BleManager(
         if (central.state == CBManagerStatePoweredOn) {
             val services: MutableList<CBUUID> = mutableListOf()
             config.profiles.forEach { set ->
-                services.add(CBUUID.UUIDWithString(set.discoveryServiceUUID))
+                set.advertisedUUID?.let { services.add(CBUUID.UUIDWithString(it)) }
             }
             val options = mapOf<Any?, Any?>(
                 CBCentralManagerScanOptionAllowDuplicatesKey to NSNumber(false)
@@ -458,7 +469,11 @@ actual class BleManager(
     /** Adds the first profile's service; the rest are chained via the didAddService delegate. */
     private fun addAllGattServices() {
         if (config.profiles.isNotEmpty()) {
-            addGattService(0)
+            config.profiles.forEach { set ->
+                if(set.advertisedUUID == null)
+                    set.advertisedUUID = set.discoveryServiceUUID
+            }
+            addGattService(config.profiles[0])
         }
     }
 

--- a/uwbmodule/src/iosMain/kotlin/BleManager.kt
+++ b/uwbmodule/src/iosMain/kotlin/BleManager.kt
@@ -103,9 +103,8 @@ actual class BleManager(
                 // Match advertised service UUIDs against our profiles. CBUUID equality normalizes
                 // 16-bit (e.g. FFF0) vs full 128-bit base UUIDs, so no string slicing is needed.
                 config.profiles.forEach { set ->
-                    //val target = CBUUID.UUIDWithString(set.discoveryServiceUUID)
-                    if (serviceUuids.any { it.UUIDString() == set.discoveryServiceUUID  || it.UUIDString() == set.discoveryServiceUUID.slice(IntRange(4,7))  }) {
-                        NSLog("BleManager: found set=${set.discoveryServiceUUID}")
+                    val target = CBUUID.UUIDWithString(set.discoveryServiceUUID)
+                    if (serviceUuids.any { it == target }) {
                         service = set
                     }
                 }

--- a/uwbmodule/src/iosMain/kotlin/BleManager.kt
+++ b/uwbmodule/src/iosMain/kotlin/BleManager.kt
@@ -10,6 +10,13 @@ actual class BleManager(
     private val config: BleDiscoveryConfig = BleDiscoveryConfig(),
 ) {
 
+    private var InitCommand : ByteArray = byteArrayOf(  0x0A )
+    private var ConfigAndStartCommand : ByteArray = byteArrayOf(  0x0B )
+    private var StopCommand : ByteArray = byteArrayOf(  0x0C )
+
+    private var accessoryConfigurationData : Byte= 0x1
+    private var accessoryUwbDidStart : Byte = 0x2
+    private var accessoryUwbDidStop : Byte = 0x3
     private var centralManager: CBCentralManager? = null
     private var peripheralManager: CBPeripheralManager? = null
 
@@ -35,6 +42,37 @@ actual class BleManager(
     private var advertiseWhenReady = false
     private var gattServerWhenReady = false
 
+    fun enableNotifications(peripheral: CBPeripheral, characteristic: CBCharacteristic) {
+        // Step 1: Tell iOS/CoreBluetooth to turn on notifications for this characteristic
+        peripheral.setNotifyValue(enabled = true, forCharacteristic = characteristic)
+    }
+
+    private fun processConfig(peripheral: CBPeripheral, accessory: accessoryDevice?, data: ByteArray, peerId:String){
+        if (data != null) {
+            val remoteConfig = UwbSessionConfig.fromByteArray(data)
+
+            if (remoteConfig != null) {
+                NSLog("BleManager: Received config from $peerId")
+                configExchangedCallback?.invoke(peerId, remoteConfig)
+            } else {
+                NSLog("BleManager: Failed to parse config from $peerId")
+            }
+            pendingConfigs.remove(peerId)
+        }
+
+        // Step 2: Write our config to the peer (using WriteWithoutResponse to avoid needing didWriteValue callback)
+        val localCfg = pendingConfigs[peerId]
+        if (localCfg != null) {
+
+            val writeChar = accessory?.service?.writeToUUID?.let { CBUUID.UUIDWithString(it ) as CBCharacteristic }
+
+            if (writeChar != null) {
+                val configData = localCfg.toByteArray().toNSData()
+                peripheral.writeValue(configData, writeChar, CBCharacteristicWriteWithoutResponse)
+                NSLog("BleManager: Wrote config to ${peripheral.hash.toString()}")
+            }
+        }
+    }
     fun addGattService(entry: ServiceEntry){
         NSLog("BleManager: addGATTService on entry $entry")
         //val entry = config.profiles[index]
@@ -42,7 +80,7 @@ actual class BleManager(
         // Read-only for now; accessory-protocol tx-notify is future work (would add CBCharacteristicPropertyNotify).
         val readChar = CBMutableCharacteristic(
             type = CBUUID.UUIDWithString(entry.readFromUUID),
-            properties = CBCharacteristicPropertyRead,
+            properties = CBCharacteristicPropertyRead or CBCharacteristicPropertyNotify,
             value = null, // Dynamic value — served via delegate
             permissions = CBAttributePermissionsReadable
         )
@@ -187,9 +225,12 @@ actual class BleManager(
             val discovererDevice = discoveredPeripherals[peripheral.hash.toString()]
             // Step 1: Read the peer's config
             var readChar:  CBCharacteristic? = null
+            var writeChar:  CBCharacteristic? = null
 
-            didDiscoverCharacteristicsForService.characteristics?.forEach { c ->
+            didDiscoverCharacteristicsForService.characteristics?.forEachIndexed { index, c ->
+
                 NSLog("discovered char="+c.toString())
+
                 (c as? CBCharacteristic)?.let { char ->
                     if (char.UUID == discovererDevice?.service?.readFromUUID?.let {
                             CBUUID.UUIDWithString(
@@ -200,16 +241,35 @@ actual class BleManager(
                         if(readChar==null)
                             readChar = char as CBCharacteristic?
                     }
-
+                    if (char.UUID == discovererDevice?.service?.writeToUUID?.let {
+                            CBUUID.UUIDWithString(
+                                it.uppercase()
+                            )
+                        }
+                    ){
+                        if(writeChar==null)
+                            writeChar = char as CBCharacteristic?
+                    }
+                    if(char.isNotifying || index==2){
+                        NSLog("BleManager: setting notifications for characteristic ${char.UUID}")
+                        enableNotifications(peripheral,char)
+                    }
                     NSLog("characteristic found = ${c.UUID.UUIDString}")
                 }
             }
 
-            if (readChar != null) {
-                peripheral.readValueForCharacteristic(readChar)
-            } else {
-                NSLog("BleManager: Read characteristic not found")
-                centralManager?.cancelPeripheralConnection(peripheral)
+            if(writeChar != null){
+                NSLog("BleManager: write Init ")
+                val configData = InitCommand.toNSData()
+                peripheral.writeValue(configData, writeChar, CBCharacteristicWriteWithoutResponse)
+            }
+            if(false) {
+                if (readChar != null) {
+                    peripheral.readValueForCharacteristic(readChar)
+                } else {
+                    NSLog("BleManager: Read characteristic not found")
+                    centralManager?.cancelPeripheralConnection(peripheral)
+                }
             }
         }
 
@@ -229,39 +289,29 @@ actual class BleManager(
             NSLog("update characteristic = ${didUpdateValueForCharacteristic.UUID}")
             if (didUpdateValueForCharacteristic.UUID == discovererDevice?.service?.readFromUUID?.let { CBUUID.UUIDWithString(it) }){
 
-                val data = didUpdateValueForCharacteristic.value
-                if (data != null) {
-                    val remoteConfig = UwbSessionConfig.fromByteArray(data.toByteArray())
-
-                    if (remoteConfig != null) {
-                        NSLog("BleManager: Received config from $peerId")
-                        configExchangedCallback?.invoke(peerId, remoteConfig)
-                    } else {
-                        NSLog("BleManager: Failed to parse config from $peerId")
-                    }
+                processConfig( peripheral, discovererDevice,
+                    didUpdateValueForCharacteristic.value?.toByteArray() ?: byteArrayOf(), peerId)
+                if(false) {
+                    // Exchange complete, disconnect
+                    centralManager?.cancelPeripheralConnection(peripheral)
                 }
 
-                // Step 2: Write our config to the peer (using WriteWithoutResponse to avoid needing didWriteValue callback)
-                val localCfg = pendingConfigs[peerId]
-                if (localCfg != null) {
-                    val service = peripheral.services?.firstOrNull {
-                        (it as? CBService)?.UUID == discovererDevice.service.discoveryServiceUUID?.let { CBUUID.UUIDWithString(it) }
-                    } as? CBService
+            } else
+                if (didUpdateValueForCharacteristic.UUID.UUIDString.contains("af2",true)){
+                    NSLog("BleManager: notify on characteristic  ${didUpdateValueForCharacteristic.UUID.UUIDString} value = ${didUpdateValueForCharacteristic.value}")
+                    val responseByte = didUpdateValueForCharacteristic.value?.toByteArray()[0]
+                        when (responseByte) {
+                            accessoryConfigurationData -> {NSLog("BleManage: Accessory sent config")
+                                // call for incoming config data
+                                processConfig( peripheral, discovererDevice, didUpdateValueForCharacteristic.value!!.toByteArray().let { it.copyOfRange(1, it.size) }, peerId)
+                            }
+                            accessoryUwbDidStart -> NSLog("BleManage: Accessory sent didStart confirmation ")
+                            accessoryUwbDidStop ->NSLog("BleManage: Accessory sent didStop confirmation ")
+                            else -> NSLog("BleManage: Accessory sent unexpected response $responseByte")
+                        }
 
-                    val writeChar = service?.characteristics?.firstOrNull {
-                        (it as? CBCharacteristic)?.UUID == discovererDevice.service.writeToUUID?.let { CBUUID.UUIDWithString(it) }
-                    } as? CBCharacteristic
-
-                    if (writeChar != null) {
-                        val configData = localCfg.toByteArray().toNSData()
-                        peripheral.writeValue(configData, writeChar, CBCharacteristicWriteWithoutResponse)
-                        NSLog("BleManager: Wrote config to ${peripheral.hash.toString()}")
-                    }
                 }
-                // Exchange complete, disconnect
-                centralManager?.cancelPeripheralConnection(peripheral)
-                pendingConfigs.remove(peerId)
-            }
+
         }
         // Note: didWriteValueForCharacteristic omitted to avoid ObjC selector conflict
         // Using WriteWithoutResponse instead

--- a/uwbmodule/src/iosMain/kotlin/BleManager.kt
+++ b/uwbmodule/src/iosMain/kotlin/BleManager.kt
@@ -103,8 +103,8 @@ actual class BleManager(
                 // Match advertised service UUIDs against our profiles. CBUUID equality normalizes
                 // 16-bit (e.g. FFF0) vs full 128-bit base UUIDs, so no string slicing is needed.
                 config.profiles.forEach { set ->
-                    val target = CBUUID.UUIDWithString(set.discoveryServiceUUID)
-                    if (serviceUuids.any { it == target }) {
+                    //val target = CBUUID.UUIDWithString(set.discoveryServiceUUID)
+                    if (serviceUuids.any { it.UUIDString() == set.discoveryServiceUUID  || it.UUIDString() == set.discoveryServiceUUID.slice(IntRange(4,7))  }) {
                         NSLog("BleManager: found set=${set.discoveryServiceUUID}")
                         service = set
                     }


### PR DESCRIPTION
this is for you to look at (not merge) .. I have commented out some of the android things.. 
read after connect, 
disconnect after config received/sent.. 

android and iOS now work correctly to handle notifications. altho the device property is not present after scan (see #23)
