### PR TITLE
iOS accessory ranging: UWB → BLE return path (#26)

### DIFF
--- a/uwbmodule/src/androidMain/kotlin/BleManager.kt
+++ b/uwbmodule/src/androidMain/kotlin/BleManager.kt
@@ -61,6 +61,14 @@ actual class BleManager(
     // Track discovered peripherals for GATT client connections
     private val discoveredDevices = mutableMapOf<String, AccessoryDevice>()
 
+    /** A live accessory connection kept open during ranging, for [sendToPeer] and the stop handshake. */
+    private class AccessoryConnection(
+        val gatt: BluetoothGatt,
+        val writeChar: BluetoothGattCharacteristic,
+        val queue: BleQueueManager,
+    )
+    private val accessoryConnections = mutableMapOf<String, AccessoryConnection>()
+
     /** Profiles we host on the local GATT server — only phone-to-phone (read/write) ones. */
     private fun serverProfiles(): List<UwbProfile> =
         config.profiles.filter { it.exchange == ExchangeProtocol.ReadWrite && it.readFromUuid != null }
@@ -74,6 +82,12 @@ actual class BleManager(
         } else {
             Log.e(TAG, "failed to parse config from $peerId")
         }
+    }
+
+    /** Deliver an accessory's raw configuration blob (opaque — wrapped, not parsed as our envelope). */
+    private fun deliverAccessoryConfig(peerId: String, raw: ByteArray) {
+        Log.d(TAG, "received accessory config from $peerId (${raw.size} bytes)")
+        configExchangedCallback?.invoke(peerId, UwbSessionConfig(0, 0, 0, ByteArray(0), accessoryData = raw))
     }
 
     // ---- Scan callback ----
@@ -482,6 +496,9 @@ actual class BleManager(
                                         BluetoothGattCharacteristic.WRITE_TYPE_NO_RESPONSE
                                     )
                                 )
+                                // Keep the connection open for the rest of the accessory protocol
+                                // (configure-and-start, stop) — see sendToPeer.
+                                queue?.let { accessoryConnections[peerId] = AccessoryConnection(gatt, writeChar, it) }
                                 Log.d(TAG, "GATT client: sent accessory init to $peerId")
                             } else {
                                 Log.e(TAG, "GATT client: accessory characteristics not found on $peerId")
@@ -548,12 +565,17 @@ actual class BleManager(
                     if (value.isEmpty()) return
                     when (value[0]) {
                         NI_ACCESSORY_CONFIG_DATA -> {
+                            // Opaque accessory config — deliver raw; the UWB layer builds the session
+                            // and replies (via sendToPeer) with configure-and-start. Stay connected.
                             Log.d(TAG, "GATT client: accessory sent config")
-                            deliverRemoteConfig(peerId, value.copyOfRange(1, value.size))
-                            gatt.disconnect()
+                            deliverAccessoryConfig(peerId, value.copyOfRange(1, value.size))
                         }
                         NI_ACCESSORY_DID_START -> Log.d(TAG, "GATT client: accessory did start")
-                        NI_ACCESSORY_DID_STOP -> Log.d(TAG, "GATT client: accessory did stop")
+                        NI_ACCESSORY_DID_STOP -> {
+                            Log.d(TAG, "GATT client: accessory did stop")
+                            accessoryConnections.remove(peerId)
+                            gatt.disconnect()
+                        }
                         else -> Log.d(TAG, "GATT client: unexpected accessory response ${value[0]}")
                     }
                 }
@@ -590,11 +612,31 @@ actual class BleManager(
         }
     }
 
+    @RequiresPermission(BLUETOOTH_CONNECT)
+    actual fun sendToPeer(peerId: String, data: ByteArray) {
+        val conn = accessoryConnections[peerId]
+        if (conn == null) {
+            Log.d(TAG, "sendToPeer: no open accessory connection for $peerId")
+            return
+        }
+        conn.queue.enqueue(
+            BleCommand.WriteCharacteristic(
+                conn.writeChar, data,
+                BluetoothGattCharacteristic.WRITE_TYPE_NO_RESPONSE
+            )
+        )
+        Log.d(TAG, "sendToPeer: wrote ${data.size} bytes to $peerId")
+    }
+
     @RequiresPermission(BLUETOOTH_SCAN)
     actual fun cleanup() {
         stopScanning()
         stopAdvertising()
         stopGattServer()
+        if (hasConnectPermission()) {
+            accessoryConnections.values.forEach { it.gatt.disconnect() }
+        }
+        accessoryConnections.clear()
         discoveredDevices.clear()
         deviceDiscoveredCallback = null
         configExchangedCallback = null

--- a/uwbmodule/src/androidMain/kotlin/MultiplatformUwbManager.android.kt
+++ b/uwbmodule/src/androidMain/kotlin/MultiplatformUwbManager.android.kt
@@ -22,6 +22,13 @@ actual class MultiplatformUwbManager(private val androidUwbManager: UwbManager? 
 
     private var rangingCallback: ((String, Double, Double?, Double?) -> Unit)? = null
     private var errorCallback: ((String) -> Unit)? = null
+
+    /**
+     * Stored for `expect` parity; unused on Android. androidx.core.uwb takes all ranging parameters
+     * up front and generates nothing post-`prepareSession`, so there is no data to send back to a peer
+     * (unlike iOS, where NI produces shareable configuration data after the session runs).
+     */
+    private var sendToPeerCallback: ((String, ByteArray) -> Unit)? = null
     private val coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
 
     /** The session scope obtained during [initialize], which provides our local UWB address. */
@@ -91,6 +98,14 @@ actual class MultiplatformUwbManager(private val androidUwbManager: UwbManager? 
         val scope = sessionScope
         if (scope == null) {
             errorCallback?.invoke("UWB not initialized. Call initialize() first.")
+            return
+        }
+
+        if (remoteConfig.accessoryData != null) {
+            // Host -> accessory ranging. androidx.core.uwb needs explicit FiRa parameters; mapping the
+            // accessory's configuration blob into RangingParameters is vendor-specific and hardware-
+            // dependent, so it is not implemented here (the iOS NI accessory path is the focus).
+            errorCallback?.invoke("Accessory ranging not yet supported on Android for $peerId")
             return
         }
 
@@ -187,6 +202,10 @@ actual class MultiplatformUwbManager(private val androidUwbManager: UwbManager? 
 
     actual fun setRangingCallback(callback: (peerId: String, distance: Double, azimuth: Double?, elevation: Double?) -> Unit) {
         rangingCallback = callback
+    }
+
+    actual fun setSendToPeerCallback(callback: (peerId: String, data: ByteArray) -> Unit) {
+        sendToPeerCallback = callback
     }
 
     actual fun setErrorCallback(callback: (error: String) -> Unit) {

--- a/uwbmodule/src/commonMain/kotlin/BleManager.kt
+++ b/uwbmodule/src/commonMain/kotlin/BleManager.kt
@@ -44,6 +44,14 @@ expect class BleManager {
      */
     fun setConfigExchangedCallback(callback: (peerId: String, remoteConfig: UwbSessionConfig) -> Unit)
 
+    /**
+     * Write [data] to a still-connected accessory's control characteristic.
+     *
+     * Used by the accessory protocol after the initial config exchange (e.g. configure-and-start with
+     * iOS's shareable data, or stop). No-op if [peerId] isn't a connected accessory.
+     */
+    fun sendToPeer(peerId: String, data: ByteArray)
+
     /** Clean up BLE resources. Call when done using the manager. */
     fun cleanup()
 }

--- a/uwbmodule/src/commonMain/kotlin/DeviceDiscoveryManager.kt
+++ b/uwbmodule/src/commonMain/kotlin/DeviceDiscoveryManager.kt
@@ -73,6 +73,9 @@ class DeviceDiscoveryManager(
     /** Peers we've initiated a config exchange with (to avoid duplicates). */
     private val pendingExchanges = mutableSetOf<String>()
 
+    /** Accessory peers — these stay BLE-connected during ranging and need a stop handshake. */
+    private val accessoryPeers = mutableSetOf<String>()
+
     companion object {
         /** Devices not seen within this window are considered stale and removed. */
         private const val STALE_THRESHOLD_MS = 10_000L
@@ -91,6 +94,12 @@ class DeviceDiscoveryManager(
 
         multiplatformUwbManager.setRangingCallback { peerId , distance , azimuth, elevation ->
             scope.launch { onRangingResult(peerId, distance, azimuth, elevation ) }
+        }
+
+        // Return path for the accessory protocol: data the UWB layer generates (e.g. iOS shareable
+        // configuration data) is written back to the accessory over the still-open BLE connection.
+        multiplatformUwbManager.setSendToPeerCallback { peerId, data ->
+            bleManager.sendToPeer(peerId, data)
         }
 
         multiplatformUwbManager.setErrorCallback { error ->
@@ -140,15 +149,20 @@ class DeviceDiscoveryManager(
         bleManager.stopAdvertising()
         bleManager.stopGattServer()
 
-        // Stop all active UWB ranging sessions
+        // Stop all active UWB ranging sessions. Accessory peers also get a BLE stop command so the
+        // accessory ends ranging and the BLE layer disconnects after its didStop confirmation.
         _nearbyDevices.value.forEach { device ->
             multiplatformUwbManager.stopRanging(device.id)
+            if (device.id in accessoryPeers) {
+                bleManager.sendToPeer(device.id, byteArrayOf(NI_ACCESSORY_STOP))
+            }
         }
 
         // Clear state
         _nearbyDevices.value = emptyList()
         exchangedPeers.clear()
         pendingExchanges.clear()
+        accessoryPeers.clear()
     }
 
     /**
@@ -224,6 +238,7 @@ class DeviceDiscoveryManager(
             if (peerId in exchangedPeers) return
             pendingExchanges.remove(peerId)
             exchangedPeers.add(peerId)
+            if (remoteConfig.accessoryData != null) accessoryPeers.add(peerId)
 
             emitEvent(
                 EventType.ConfigExchangeComplete, peerId,

--- a/uwbmodule/src/commonMain/kotlin/MultiplatformUwbManager.kt
+++ b/uwbmodule/src/commonMain/kotlin/MultiplatformUwbManager.kt
@@ -36,6 +36,16 @@ expect class MultiplatformUwbManager {
     /** Register callback for ranging distance updates. */
     fun setRangingCallback(callback: (peerId: String, distance: Double, azimuth: Double?, elevation: Double?) -> Unit)
 
+    /**
+     * Register the outbound channel used to send data back to a peer over BLE.
+     *
+     * Needed for accessory ranging on iOS: `NINearbyAccessoryConfiguration` produces shareable
+     * configuration data *after* the session runs, which must be written to the accessory. The
+     * orchestrator wires this to [BleManager.sendToPeer]. Unused on Android (no data is generated
+     * post-run there).
+     */
+    fun setSendToPeerCallback(callback: (peerId: String, data: ByteArray) -> Unit)
+
     /** Register callback for errors. */
     fun setErrorCallback(callback: (error: String) -> Unit)
 

--- a/uwbmodule/src/commonMain/kotlin/UwbSessionConfig.kt
+++ b/uwbmodule/src/commonMain/kotlin/UwbSessionConfig.kt
@@ -24,6 +24,14 @@ data class UwbSessionConfig(
      * use the same key. Exchanged here so the two ends can agree on one.
      */
     val sessionKey: ByteArray? = null,
+    /**
+     * Opaque Apple/Qorvo Nearby-Interaction **Accessory Configuration Data** (iOS accessory) or null.
+     *
+     * Carries the raw bytes an accessory sends so the iOS NI manager can build a
+     * `NINearbyAccessoryConfiguration`. Mutually exclusive with [discoveryToken] (peer-to-peer): the
+     * BLE layer wraps the accessory's raw payload in this field locally — it is not our own envelope.
+     */
+    val accessoryData: ByteArray? = null,
 ) {
     /**
      * Serialize to a simple binary format for BLE GATT exchange.
@@ -34,13 +42,15 @@ data class UwbSessionConfig(
      * [2B uwbAddr.size][uwbAddr bytes]
      * [2B token.size][token bytes]   // size=0 if null
      * [2B key.size][key bytes]       // optional trailer; absent or size=0 if null
+     * [2B acc.size][acc bytes]       // optional trailer; absent or size=0 if null
      * ```
-     * The session-key trailer is optional so older payloads (without it) still parse.
+     * The session-key and accessory-data trailers are optional so older payloads still parse.
      */
     fun toByteArray(): ByteArray {
         val tokenBytes = discoveryToken ?: ByteArray(0)
         val keyBytes = sessionKey ?: ByteArray(0)
-        val size = 1 + 4 + 4 + 4 + 2 + uwbAddress.size + 2 + tokenBytes.size + 2 + keyBytes.size
+        val accBytes = accessoryData ?: ByteArray(0)
+        val size = 1 + 4 + 4 + 4 + 2 + uwbAddress.size + 2 + tokenBytes.size + 2 + keyBytes.size + 2 + accBytes.size
         val buf = ByteArray(size)
         var pos = 0
 
@@ -81,6 +91,12 @@ data class UwbSessionConfig(
         buf[pos++] = (keyBytes.size shr 8).toByte()
         buf[pos++] = keyBytes.size.toByte()
         keyBytes.copyInto(buf, pos)
+        pos += keyBytes.size
+
+        // accessoryData
+        buf[pos++] = (accBytes.size shr 8).toByte()
+        buf[pos++] = accBytes.size.toByte()
+        accBytes.copyInto(buf, pos)
 
         return buf
     }
@@ -92,12 +108,15 @@ data class UwbSessionConfig(
         val otherToken = other.discoveryToken ?: ByteArray(0)
         val thisKey = sessionKey ?: ByteArray(0)
         val otherKey = other.sessionKey ?: ByteArray(0)
+        val thisAcc = accessoryData ?: ByteArray(0)
+        val otherAcc = other.accessoryData ?: ByteArray(0)
         return sessionId == other.sessionId &&
                 channel == other.channel &&
                 preambleIndex == other.preambleIndex &&
                 uwbAddress.contentEquals(other.uwbAddress) &&
                 thisToken.contentEquals(otherToken) &&
-                thisKey.contentEquals(otherKey)
+                thisKey.contentEquals(otherKey) &&
+                thisAcc.contentEquals(otherAcc)
     }
 
     override fun hashCode(): Int {
@@ -107,6 +126,7 @@ data class UwbSessionConfig(
         result = 31 * result + uwbAddress.contentHashCode()
         result = 31 * result + (discoveryToken?.contentHashCode() ?: 0)
         result = 31 * result + (sessionKey?.contentHashCode() ?: 0)
+        result = 31 * result + (accessoryData?.contentHashCode() ?: 0)
         return result
     }
 
@@ -138,7 +158,15 @@ data class UwbSessionConfig(
             // Optional session-key trailer (absent in older payloads).
             val sessionKey = if (pos + 2 <= bytes.size) {
                 val keyLen = readShort(bytes, pos); pos += 2
-                if (keyLen > 0 && pos + keyLen <= bytes.size) bytes.copyOfRange(pos, pos + keyLen) else null
+                if (keyLen > 0 && pos + keyLen <= bytes.size) bytes.copyOfRange(pos, pos + keyLen).also { pos += keyLen } else null
+            } else {
+                null
+            }
+
+            // Optional accessory-data trailer (absent in older payloads).
+            val accessoryData = if (pos + 2 <= bytes.size) {
+                val accLen = readShort(bytes, pos); pos += 2
+                if (accLen > 0 && pos + accLen <= bytes.size) bytes.copyOfRange(pos, pos + accLen) else null
             } else {
                 null
             }
@@ -150,6 +178,7 @@ data class UwbSessionConfig(
                 uwbAddress = uwbAddress,
                 discoveryToken = discoveryToken,
                 sessionKey = sessionKey,
+                accessoryData = accessoryData,
             )
         }
 

--- a/uwbmodule/src/commonTest/kotlin/com/dustedrob/uwb/UwbSessionConfigTest.kt
+++ b/uwbmodule/src/commonTest/kotlin/com/dustedrob/uwb/UwbSessionConfigTest.kt
@@ -158,5 +158,34 @@ class UwbSessionConfigTest {
         assertNotNull(restored)
         assertEquals(sid, restored.sessionId)
         assertNull(restored.sessionKey)
+        assertNull(restored.accessoryData)
+    }
+
+    @Test
+    fun roundtripWithAccessoryData() {
+        val acc = ByteArray(40) { (it * 7).toByte() }
+        val config = UwbSessionConfig(
+            sessionId = 0,
+            channel = 0,
+            preambleIndex = 0,
+            uwbAddress = ByteArray(0),
+            accessoryData = acc,
+        )
+        val restored = UwbSessionConfig.fromByteArray(config.toByteArray())
+        assertNotNull(restored)
+        assertNotNull(restored.accessoryData)
+        assertTrue(acc.contentEquals(restored.accessoryData!!))
+        assertNull(restored.discoveryToken)
+        assertNull(restored.sessionKey)
+        assertEquals(config, restored)
+    }
+
+    @Test
+    fun accessoryDataNullWhenAbsent() {
+        val config = UwbSessionConfig(1, 2, 3, byteArrayOf(9), sessionKey = byteArrayOf(1, 2, 3, 4, 5, 6, 7, 8))
+        val restored = UwbSessionConfig.fromByteArray(config.toByteArray())
+        assertNotNull(restored)
+        assertNull(restored.accessoryData)
+        assertTrue(restored.sessionKey!!.size == 8)
     }
 }

--- a/uwbmodule/src/iosMain/kotlin/BleManager.kt
+++ b/uwbmodule/src/iosMain/kotlin/BleManager.kt
@@ -30,6 +30,13 @@ actual class BleManager(
     // Pending config exchanges, keyed by peripheral UUID
     private val pendingConfigs = mutableMapOf<String, UwbSessionConfig>()
 
+    /** Live accessory connections kept open during ranging, for [sendToPeer] and the stop handshake. */
+    private data class AccessoryConnection(
+        val peripheral: CBPeripheral,
+        val writeChar: CBCharacteristic,
+    )
+    private val accessoryConnections = mutableMapOf<String, AccessoryConnection>()
+
     // Deferred operations waiting for poweredOn
     private var scanWhenReady = false
     private var advertiseWhenReady = false
@@ -48,6 +55,12 @@ actual class BleManager(
         } else {
             NSLog("BleManager: failed to parse config from $peerId")
         }
+    }
+
+    /** Deliver an accessory's raw configuration blob (opaque — wrapped, not parsed as our envelope). */
+    private fun deliverAccessoryConfig(peerId: String, raw: ByteArray) {
+        NSLog("BleManager: received accessory config from $peerId (${raw.size} bytes)")
+        configExchangedCallback?.invoke(peerId, UwbSessionConfig(0, 0, 0, ByteArray(0), accessoryData = raw))
     }
 
     /** Find a characteristic on a discovered service by UUID string (CBUUID normalizes short/long). */
@@ -191,6 +204,10 @@ actual class BleManager(
                         peripheral.setNotifyValue(true, notifyChar)
                         val initCmd = profile.initCommand ?: byteArrayOf(NI_ACCESSORY_INIT_COMMAND)
                         peripheral.writeValue(initCmd.toNSData(), writeChar, CBCharacteristicWriteWithoutResponse)
+                        // Keep the connection open for the rest of the accessory protocol
+                        // (configure-and-start, stop) — see sendToPeer.
+                        accessoryConnections[peripheral.identifier.UUIDString] =
+                            AccessoryConnection(peripheral, writeChar)
                         NSLog("BleManager: sent accessory init to ${peripheral.identifier.UUIDString}")
                     } else {
                         NSLog("BleManager: accessory characteristics not found")
@@ -252,13 +269,18 @@ actual class BleManager(
                     if (bytes == null || bytes.isEmpty()) return
                     when (bytes[0]) {
                         NI_ACCESSORY_CONFIG_DATA -> {
+                            // Opaque accessory config — deliver raw; the NI layer builds the session
+                            // and replies (via sendToPeer) with configure-and-start. Stay connected.
                             NSLog("BleManager: accessory sent config")
-                            deliverRemoteConfig(peerId, bytes.copyOfRange(1, bytes.size))
+                            deliverAccessoryConfig(peerId, bytes.copyOfRange(1, bytes.size))
+                        }
+                        NI_ACCESSORY_DID_START -> NSLog("BleManager: accessory did start")
+                        NI_ACCESSORY_DID_STOP -> {
+                            NSLog("BleManager: accessory did stop")
+                            accessoryConnections.remove(peerId)
                             centralManager?.cancelPeripheralConnection(peripheral)
                             pendingConfigs.remove(peerId)
                         }
-                        NI_ACCESSORY_DID_START -> NSLog("BleManager: accessory did start")
-                        NI_ACCESSORY_DID_STOP -> NSLog("BleManager: accessory did stop")
                         else -> NSLog("BleManager: unexpected accessory response ${bytes[0]}")
                     }
                 }
@@ -472,10 +494,22 @@ actual class BleManager(
         NSLog("BleManager: Connecting to $peerId for config exchange")
     }
 
+    actual fun sendToPeer(peerId: String, data: ByteArray) {
+        val conn = accessoryConnections[peerId]
+        if (conn == null) {
+            NSLog("BleManager: sendToPeer no open accessory connection for $peerId")
+            return
+        }
+        conn.peripheral.writeValue(data.toNSData(), conn.writeChar, CBCharacteristicWriteWithoutResponse)
+        NSLog("BleManager: sendToPeer wrote ${data.size} bytes to $peerId")
+    }
+
     actual fun cleanup() {
         stopScanning()
         stopAdvertising()
         stopGattServer()
+        accessoryConnections.values.forEach { centralManager?.cancelPeripheralConnection(it.peripheral) }
+        accessoryConnections.clear()
         discoveredPeripherals.clear()
         pendingConfigs.clear()
         deviceDiscoveredCallback = null

--- a/uwbmodule/src/iosMain/kotlin/MultiplatformUwbManager.ios.kt
+++ b/uwbmodule/src/iosMain/kotlin/MultiplatformUwbManager.ios.kt
@@ -15,6 +15,7 @@ import platform.NearbyInteraction.NIAlgorithmConvergenceStatusReasonInsufficient
 import platform.NearbyInteraction.NIAlgorithmConvergenceStatusReasonInsufficientMovement
 import platform.NearbyInteraction.NIAlgorithmConvergenceStatusReasonInsufficientVerticalSweep
 import platform.NearbyInteraction.NIDiscoveryToken
+import platform.NearbyInteraction.NINearbyAccessoryConfiguration
 import platform.NearbyInteraction.NINearbyObject
 import platform.NearbyInteraction.NINearbyObjectRemovalReason
 import platform.NearbyInteraction.NINearbyPeerConfiguration
@@ -29,6 +30,12 @@ actual class MultiplatformUwbManager {
     private var niSession: NISession? = null
     private var rangingCallback: ((String, Double, Double?, Double?) -> Unit)? = null
     private var errorCallback: ((String) -> Unit)? = null
+
+    /** Outbound channel to write data back to a peer over BLE (wired to BleManager.sendToPeer). */
+    private var sendToPeerCallback: ((String, ByteArray) -> Unit)? = null
+
+    /** The accessory peer currently being ranged (single-accessory session; multi-accessory is future). */
+    private var accessoryPeerId: String? = null
 
     /**
      * NearbyInteraction direction APIs (`horizontalAngle`, `verticalDirectionEstimate`) are iOS 16+.
@@ -109,6 +116,23 @@ actual class MultiplatformUwbManager {
             return
         }
 
+        // Accessory ranging: build an accessory configuration from the accessory's data blob. NI then
+        // generates shareable configuration data (see didGenerateShareableConfigurationData), which we
+        // write back to the accessory over BLE to actually start ranging.
+        val accessoryData = remoteConfig.accessoryData
+        if (accessoryData != null) {
+            val config = try {
+                NINearbyAccessoryConfiguration(accessoryData.toNSData(), null)
+            } catch (e: Exception) {
+                errorCallback?.invoke("Failed to build accessory configuration for $peerId: ${e.message}")
+                return
+            }
+            accessoryPeerId = peerId
+            NSLog("UwbManager: Starting accessory ranging with $peerId")
+            session.runWithConfiguration(config)
+            return
+        }
+
         val tokenBytes = remoteConfig.discoveryToken
         if (tokenBytes == null || tokenBytes.isEmpty()) {
             errorCallback?.invoke("No discovery token in remote config for $peerId")
@@ -144,7 +168,8 @@ actual class MultiplatformUwbManager {
 
     actual fun stopRanging(peerId: String) {
         activePeers.remove(peerId)
-        if (activePeers.isEmpty()) {
+        if (peerId == accessoryPeerId) accessoryPeerId = null
+        if (activePeers.isEmpty() && accessoryPeerId == null) {
             niSession?.pause()
             NSLog("UwbManager: Paused session (no active peers)")
         }
@@ -152,6 +177,10 @@ actual class MultiplatformUwbManager {
 
     actual fun setRangingCallback(callback: (peerId: String, distance: Double, azimuth: Double?, elevation: Double?) -> Unit) {
         rangingCallback = callback
+    }
+
+    actual fun setSendToPeerCallback(callback: (peerId: String, data: ByteArray) -> Unit) {
+        sendToPeerCallback = callback
     }
 
     actual fun setErrorCallback(callback: (error: String) -> Unit) {
@@ -162,6 +191,7 @@ actual class MultiplatformUwbManager {
         niSession?.invalidate()
         niSession = null
         activePeers.clear()
+        accessoryPeerId = null
         localDiscoveryToken = null
         sessionDelegate = null
         NSLog("UwbManager: Cleanup completed")
@@ -177,8 +207,11 @@ actual class MultiplatformUwbManager {
                     if (obj is NINearbyObject) {
                         val distance = obj.distance.toDouble()
                         if (!distance.isNaN()) {
+                            // Accessory objects aren't in activePeers (keyed by peer tokens), so fall
+                            // back to the tracked accessory peer.
                             val peerId = activePeers.entries
-                                .find { it.value == obj.discoveryToken }?.key ?: "unknown"
+                                .find { it.value == obj.discoveryToken }?.key
+                                ?: accessoryPeerId ?: "unknown"
 
                             // Azimuth (`horizontalAngle`) is iOS 16+ and is NaN until camera-assistance
                             // convergence, so only emit it when available and valid.
@@ -234,7 +267,16 @@ actual class MultiplatformUwbManager {
             didGenerateShareableConfigurationData: NSData,
             forObject: NINearbyObject
         ) {
-            // Shareable configuration data generated — not used in our BLE-based exchange
+            // Accessory ranging: NI produced the data the accessory needs to start. Send it back over
+            // BLE, prefixed with the configure-and-start message id.
+            val peerId = accessoryPeerId
+            if (peerId == null) {
+                NSLog("UwbManager: shareable config generated but no accessory peer tracked")
+                return
+            }
+            val payload = byteArrayOf(NI_ACCESSORY_CONFIGURE_AND_START) + didGenerateShareableConfigurationData.toByteArray()
+            NSLog("UwbManager: sending configure-and-start to $peerId (${payload.size} bytes)")
+            sendToPeerCallback?.invoke(peerId, payload)
         }
 
         override fun session(


### PR DESCRIPTION
Implements the iOS half of accessory ranging described in #26: A way for the iOS UWB/NI layer to send data back to a device over BLE.
  
  To range with a UWB accessory (not another phone), iOS uses NINearbyAccessoryConfiguration. Unlike the phone-to-phone discovery-token flow, NI
  generates "shareable configuration data" only after session.run() — and that data must be written back to the accessory over BLE to actually start
  ranging. 


  **UWB → BLE**

  - MultiplatformUwbManager.setSendToPeerCallback + BleManager.sendToPeer(peerId, data).
  - DeviceDiscoveryManager wires them together (mirroring the existing rangingCallback / configExchangedCallback flow), tracks accessory peers, and
  drives the stop handshake.
  
  iOS → Accessory

  - startRanging branches on accessoryData → builds NINearbyAccessoryConfiguration, runs the session.
  - didGenerateShareableConfigurationData (was a no-op) now sends [configure-and-start] + data back to the accessory over BLE.
  - BleManager keeps the accessory connection open after the initial exchange (for configure-and-start / stop) and disconnects on the accessory's
  didStop.
  - didUpdateNearbyObjects resolves distance to the tracked accessory peer.

  Common model 

  UwbSessionConfig now has an optional `accessoryData` field 


`Android TODO`

  Android is asymmetric: androidx.core.uwb takes all parameters up front and generates nothing post-prepareSession, so it needs no return path.

