### PR TITLE
update misc for android ranging to Qorvo accessories

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,18 @@ Alternatively, set your Team ID in `iosApp/Configuration/Config.xcconfig`:
 ```
 TEAM_ID=YOUR_TEAM_ID_HERE
 ```
+you will also need to set JAVA_HOME in the build phases or edit the  `iosApp/Configuration/Config.xcconfig`
+from the console do `which java`, and put in the path to the folder containing the bin folder
+like this 
+```
+which java
+/opt/homebrew/opt/openjdk@17/bin/java
+```
+you need add the line
+```
+JAVA_HOME=/opt/homebrew/opt/openjdk@17
+```
+
 
 Free (Personal Team) provisioning profiles are valid for 7 days and must be renewed by re-building from Xcode.
 

--- a/composeApp/src/commonMain/kotlin/AccessoryProfiles.kt
+++ b/composeApp/src/commonMain/kotlin/AccessoryProfiles.kt
@@ -12,8 +12,7 @@ import com.dustedrob.uwb.UwbProfile
 object QorvoNearbyProfile : UwbProfile {
     override val name = "QorvoNearby"
 
-    // The accessory advertises a beacon UUID distinct from the GATT service it hosts.
-    override val advertisedUuid = "11000000-27B9-42F0-82AA-2E951747BBF9"
+
     override val discoveryServiceUuid = "2E938FD0-6A61-11ED-A1EB-0242AC120002"
 
     override val readFromUuid = "2E93941C-6A61-11ED-A1EB-0242AC120002"   // readable char (props 0x2)
@@ -31,6 +30,20 @@ object NordicUartProfile : UwbProfile {
     override val writeToUuid = "6E400002-B5A3-F393-E0A9-E50E24DCCA9E"    // RX (host -> accessory)
     override val notifyFromUuid = "6E400003-B5A3-F393-E0A9-E50E24DCCA9E" // TX (accessory -> host, notify)
     override val readFromUuid: String? = null
+
+    override val exchange = ExchangeProtocol.AccessoryNotify
+}
+
+object CNCustom : UwbProfile {
+    override val name = "CNCustom"
+
+    // The accessory advertises a beacon UUID distinct from the GATT service it hosts.
+    override val advertisedUuid = "11000000-27B9-42F0-82AA-2E951747BBF9"
+    override val discoveryServiceUuid = "2E938FD0-6A61-11ED-A1EB-0242AC120002"
+
+    override val readFromUuid = "2E93941C-6A61-11ED-A1EB-0242AC120002"   // readable char (props 0x2)
+    override val writeToUuid = "2E93998A-6A61-11ED-A1EB-0242AC120002"    // control / rx char (props 0xC)
+    override val notifyFromUuid = "2E939AF2-6A61-11ED-A1EB-0242AC120002" // accessory tx / notify (props 0x10)
 
     override val exchange = ExchangeProtocol.AccessoryNotify
 }

--- a/composeApp/src/commonMain/kotlin/AccessoryProfiles.kt
+++ b/composeApp/src/commonMain/kotlin/AccessoryProfiles.kt
@@ -12,7 +12,6 @@ import com.dustedrob.uwb.UwbProfile
 object QorvoNearbyProfile : UwbProfile {
     override val name = "QorvoNearby"
 
-
     override val discoveryServiceUuid = "2E938FD0-6A61-11ED-A1EB-0242AC120002"
 
     override val readFromUuid = "2E93941C-6A61-11ED-A1EB-0242AC120002"   // readable char (props 0x2)
@@ -34,16 +33,3 @@ object NordicUartProfile : UwbProfile {
     override val exchange = ExchangeProtocol.AccessoryNotify
 }
 
-object CNCustom : UwbProfile {
-    override val name = "CNCustom"
-
-    // The accessory advertises a beacon UUID distinct from the GATT service it hosts.
-    override val advertisedUuid = "11000000-27B9-42F0-82AA-2E951747BBF9"
-    override val discoveryServiceUuid = "2E938FD0-6A61-11ED-A1EB-0242AC120002"
-
-    override val readFromUuid = "2E93941C-6A61-11ED-A1EB-0242AC120002"   // readable char (props 0x2)
-    override val writeToUuid = "2E93998A-6A61-11ED-A1EB-0242AC120002"    // control / rx char (props 0xC)
-    override val notifyFromUuid = "2E939AF2-6A61-11ED-A1EB-0242AC120002" // accessory tx / notify (props 0x10)
-
-    override val exchange = ExchangeProtocol.AccessoryNotify
-}

--- a/composeApp/src/commonMain/kotlin/App.kt
+++ b/composeApp/src/commonMain/kotlin/App.kt
@@ -162,7 +162,7 @@ private fun LocalDeviceInfo(config: UwbSessionConfig?, isScanning: Boolean) {
                     (byte.toInt() and 0xFF).toString(16).padStart(2, '0').uppercase()
                 }
                 Text("UWB Address: $addrHex", style = MaterialTheme.typography.caption)
-                Text("Session ID: ${config.sessionId}  Channel: ${config.channel}", style = MaterialTheme.typography.caption)
+                Text("Session ID: ${config.sessionId.toHexString()}  Channel: ${config.channel}", style = MaterialTheme.typography.caption)
             } else {
                 Text(
                     if (isScanning) "Initializing UWB…" else "Not started",
@@ -215,7 +215,7 @@ private fun DeviceItem(device: NearbyDevice) {
                 )
                 if (device.sessionId != null) {
                     Text(
-                        text = "Session: ${device.sessionId}  Ch: ${device.channel}",
+                        text = "Session: ${device.sessionId!!.toHexString()}  Ch: ${device.channel}",
                         style = MaterialTheme.typography.caption
                     )
                 }

--- a/iosApp/Configuration/Config.xcconfig
+++ b/iosApp/Configuration/Config.xcconfig
@@ -1,3 +1,4 @@
 TEAM_ID=
 BUNDLE_ID=com.dustedrob.multiplatformuwb.multiplatformuwb
 APP_NAME=Multi Platform UWB
+JAVA_HOME=

--- a/uwbmodule/src/androidMain/kotlin/BleManager.kt
+++ b/uwbmodule/src/androidMain/kotlin/BleManager.kt
@@ -85,9 +85,28 @@ actual class BleManager(
     }
 
     /** Deliver an accessory's raw configuration blob (opaque — wrapped, not parsed as our envelope). */
+    @RequiresPermission(BLUETOOTH_CONNECT)
     private fun deliverAccessoryConfig(peerId: String, raw: ByteArray) {
         Log.d(TAG, "received accessory config from $peerId (${raw.size} bytes)")
-        configExchangedCallback?.invoke(peerId, UwbSessionConfig(0, 0, 0, ByteArray(0), accessoryData = raw))
+        val remoteConfig = raw.let { UwbSessionConfig.fromByteArray(it) }
+        if (remoteConfig != null) {
+            // if the session key is not set
+            if(remoteConfig.sessionKey?.size == 0)
+                // use the generated one in the localConfig
+                remoteConfig.sessionKey = localConfig?.sessionKey
+            // if the sessionIDs don't match
+            if(remoteConfig.sessionId != localConfig?.sessionId)
+                // use the generated one in localConfig
+                remoteConfig.sessionId = localConfig?.sessionId!!
+            Log.d(TAG, "received config from $peerId")
+            configExchangedCallback?.invoke(peerId, remoteConfig) // this starts ranging
+            val message = byteArrayOf(ANDROID_ACCESSORY_CONFIGURE_AND_START)+ localConfig?.toByteArray()!!
+
+            Log.d(TAG,"sending config data message to accessory=${message.toHexString()}")
+            localConfig?.toByteArray()?.let { sendToPeer(peerId, message )}
+        } else {
+            Log.e(TAG, "failed to parse config from $peerId")
+        }
     }
 
     // ---- Scan callback ----
@@ -460,7 +479,7 @@ actual class BleManager(
                         return
                     }
                     queue = BleQueueManager(gatt)
-
+                    gatt.requestMtu(64);
                     when (profile.exchange) {
                         ExchangeProtocol.ReadWrite -> {
                             val readChar = profile.readFromUuid
@@ -482,15 +501,15 @@ actual class BleManager(
                                 // notifies its config back (handled in onCharacteristicChanged).
                                 gatt.setCharacteristicNotification(notifyChar, true)
                                 notifyChar.getDescriptor(cccdUuid)?.let { cccd ->
-                                    queue?.enqueue(
+                                    queue.enqueue(
                                         BleCommand.WriteDescriptor(
                                             cccd,
                                             BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE
                                         )
                                     )
                                 }
-                                val initCmd = profile.initCommand ?: byteArrayOf(NI_ACCESSORY_INIT_COMMAND)
-                                queue?.enqueue(
+                                val initCmd = profile.initCommand ?: byteArrayOf(ANDROID_ACCESSORY_INIT_COMMAND)
+                                queue.enqueue(
                                     BleCommand.WriteCharacteristic(
                                         writeChar, initCmd,
                                         BluetoothGattCharacteristic.WRITE_TYPE_NO_RESPONSE
@@ -498,7 +517,7 @@ actual class BleManager(
                                 )
                                 // Keep the connection open for the rest of the accessory protocol
                                 // (configure-and-start, stop) — see sendToPeer.
-                                queue?.let { accessoryConnections[peerId] = AccessoryConnection(gatt, writeChar, it) }
+                                queue.let { accessoryConnections[peerId] = AccessoryConnection(gatt, writeChar, it) }
                                 Log.d(TAG, "GATT client: sent accessory init to $peerId")
                             } else {
                                 Log.e(TAG, "GATT client: accessory characteristics not found on $peerId")
@@ -563,11 +582,12 @@ actual class BleManager(
                 private fun handleAccessoryNotify(gatt: BluetoothGatt, value: ByteArray) {
                     // First byte is the NI message id, the rest is the payload.
                     if (value.isEmpty()) return
+                    Log.d(TAG, "notify received ${value.size} bytes")
                     when (value[0]) {
                         NI_ACCESSORY_CONFIG_DATA -> {
                             // Opaque accessory config — deliver raw; the UWB layer builds the session
                             // and replies (via sendToPeer) with configure-and-start. Stay connected.
-                            Log.d(TAG, "GATT client: accessory sent config")
+                            Log.d(TAG, "GATT client: accessory sent config, ${value.toHexString()}")
                             deliverAccessoryConfig(peerId, value.copyOfRange(1, value.size))
                         }
                         NI_ACCESSORY_DID_START -> Log.d(TAG, "GATT client: accessory did start")

--- a/uwbmodule/src/androidMain/kotlin/BleManager.kt
+++ b/uwbmodule/src/androidMain/kotlin/BleManager.kt
@@ -30,7 +30,9 @@ import androidx.annotation.RequiresPermission
 import androidx.core.content.ContextCompat
 import java.util.UUID
 
+private const val PREFERRED_MTU: Int = 256;
 actual class BleManager(
+
     private val context: Context,
     private val config: BleDiscoveryConfig = BleDiscoveryConfig(),
 ) {
@@ -38,6 +40,7 @@ actual class BleManager(
 
     /** Client Characteristic Configuration Descriptor — used to subscribe to notifications. */
     private val cccdUuid = UUID.fromString("00002902-0000-1000-8000-00805f9b34fb")
+
 
     private data class AccessoryDevice(
         val bleDevice: BluetoothDevice? = null,
@@ -88,10 +91,14 @@ actual class BleManager(
     @RequiresPermission(BLUETOOTH_CONNECT)
     private fun deliverAccessoryConfig(peerId: String, raw: ByteArray) {
         Log.d(TAG, "received accessory config from $peerId (${raw.size} bytes)")
-        val remoteConfig = raw.let { UwbSessionConfig.fromByteArray(it) }
+        val remoteConfig = raw.let { UwbSessionConfig.fromByteArray(it, true) }
         if (remoteConfig != null) {
+            if(localConfig == null) {// fail if not set
+                Log.e(TAG, "local config not created")
+                return
+            }
             // if the session key is not set
-            if(remoteConfig.sessionKey?.size == 0)
+            if(remoteConfig.sessionKey == null )
                 // use the generated one in the localConfig
                 remoteConfig.sessionKey = localConfig?.sessionKey
             // if the sessionIDs don't match
@@ -100,15 +107,17 @@ actual class BleManager(
                 remoteConfig.sessionId = localConfig?.sessionId!!
             Log.d(TAG, "received config from $peerId")
             configExchangedCallback?.invoke(peerId, remoteConfig) // this starts ranging
-            val message = byteArrayOf(ANDROID_ACCESSORY_CONFIGURE_AND_START)+ localConfig?.toByteArray()!!
-
-            Log.d(TAG,"sending config data message to accessory=${message.toHexString()}")
-            localConfig?.toByteArray()?.let { sendToPeer(peerId, message )}
+            Log.d(TAG," local device addr=${localConfig!!.uwbAddress.toHexString()} remote device addr=${remoteConfig.uwbAddress.toHexString()}")
         } else {
             Log.e(TAG, "failed to parse config from $peerId")
         }
     }
 
+    @RequiresPermission(BLUETOOTH_CONNECT)
+    private fun cleanUpGatt(gatt:BluetoothGatt ) {
+        gatt.disconnect();
+        gatt.close();
+    }
     // ---- Scan callback ----
 
     private val scanCallback = object : ScanCallback() {
@@ -301,6 +310,7 @@ actual class BleManager(
         }
     }
 
+
     // ---- Public API: Advertising ----
 
     @RequiresPermission(BLUETOOTH_CONNECT)
@@ -448,15 +458,19 @@ actual class BleManager(
         var queue: BleQueueManager? = null
 
         try {
-            device.connectGatt(context, false, object : BluetoothGattCallback() {
+            device.connectGatt(context, true, object : BluetoothGattCallback()  {
                 @RequiresPermission(BLUETOOTH_CONNECT)
                 override fun onConnectionStateChange(gatt: BluetoothGatt, status: Int, newState: Int) {
+                    if (status == 133) {
+                        // Handle Error 133 cleanly
+                        cleanUpGatt(gatt);
+                    }
                     if (newState == BluetoothProfile.STATE_CONNECTED) {
                         Log.d(TAG, "GATT client: connected to $peerId, discovering services")
                         gatt.discoverServices()
                     } else if (newState == BluetoothProfile.STATE_DISCONNECTED) {
                         Log.d(TAG, "GATT client: disconnected from $peerId")
-                        gatt.close()
+                        //gatt.close()
                     }
                 }
 
@@ -478,8 +492,10 @@ actual class BleManager(
                         gatt.close()
                         return
                     }
-                    queue = BleQueueManager(gatt)
-                    gatt.requestMtu(64);
+                    // only instantiate once
+                    if(queue == null)
+                       queue = BleQueueManager(gatt)
+                    gatt.requestMtu(PREFERRED_MTU);
                     when (profile.exchange) {
                         ExchangeProtocol.ReadWrite -> {
                             val readChar = profile.readFromUuid
@@ -579,6 +595,7 @@ actual class BleManager(
                     handleAccessoryNotify(gatt, characteristic.value ?: return)
                 }
 
+                @RequiresPermission(BLUETOOTH_CONNECT)
                 private fun handleAccessoryNotify(gatt: BluetoothGatt, value: ByteArray) {
                     // First byte is the NI message id, the rest is the payload.
                     if (value.isEmpty()) return
@@ -595,6 +612,7 @@ actual class BleManager(
                             Log.d(TAG, "GATT client: accessory did stop")
                             accessoryConnections.remove(peerId)
                             gatt.disconnect()
+                            gatt.close()
                         }
                         else -> Log.d(TAG, "GATT client: unexpected accessory response ${value[0]}")
                     }
@@ -624,6 +642,7 @@ actual class BleManager(
                     // For phone-to-phone, the exchange ends once we've written our config back.
                     if (profile?.exchange == ExchangeProtocol.ReadWrite) {
                         gatt.disconnect()
+                        gatt.close()
                     }
                 }
             })
@@ -654,7 +673,7 @@ actual class BleManager(
         stopAdvertising()
         stopGattServer()
         if (hasConnectPermission()) {
-            accessoryConnections.values.forEach { it.gatt.disconnect() }
+            accessoryConnections.values.forEach { it.gatt.close() }
         }
         accessoryConnections.clear()
         discoveredDevices.clear()

--- a/uwbmodule/src/androidMain/kotlin/MultiplatformUwbManager.android.kt
+++ b/uwbmodule/src/androidMain/kotlin/MultiplatformUwbManager.android.kt
@@ -158,7 +158,7 @@ actual class MultiplatformUwbManager(private val androidUwbManager: UwbManager? 
 
                 Log.d(
                     TAG,
-                    "Starting ranging with $peerId — session=${agreed.sessionId} ch=${agreed.channel}"
+                    "Starting ranging with $peerId — session=${agreed.sessionId.toHexString()} ch=${agreed.channel}"
                 )
 
                 scope.prepareSession(rangingParameters)

--- a/uwbmodule/src/androidMain/kotlin/MultiplatformUwbManager.android.kt
+++ b/uwbmodule/src/androidMain/kotlin/MultiplatformUwbManager.android.kt
@@ -46,7 +46,7 @@ actual class MultiplatformUwbManager(private val androidUwbManager: UwbManager? 
     /** Default channel and preamble — used when generating local config. */
     private companion object {
         const val DEFAULT_CHANNEL = 9
-        const val DEFAULT_PREAMBLE_INDEX = 10
+        const val DEFAULT_PREAMBLE_INDEX = 11
         const val SESSION_KEY_SIZE = 8
     }
 
@@ -84,6 +84,8 @@ actual class MultiplatformUwbManager(private val androidUwbManager: UwbManager? 
             .also { SecureRandom().nextBytes(it) }
             .also { localSessionKey = it }
 
+        Log.d(TAG, "phone address is ${localAddress.toHexString()}")
+
         return UwbSessionConfig(
             sessionId = sessionId,
             channel = DEFAULT_CHANNEL,
@@ -101,30 +103,26 @@ actual class MultiplatformUwbManager(private val androidUwbManager: UwbManager? 
             return
         }
 
-        if (remoteConfig.accessoryData != null) {
-            // Host -> accessory ranging. androidx.core.uwb needs explicit FiRa parameters; mapping the
-            // accessory's configuration blob into RangingParameters is vendor-specific and hardware-
-            // dependent, so it is not implemented here (the iOS NI accessory path is the focus).
-            errorCallback?.invoke("Accessory ranging not yet supported on Android for $peerId")
-            return
-        }
-
         // Cancel any existing ranging job for this peer
         activeJobs[peerId]?.cancel()
 
         val job = coroutineScope.launch {
             try {
                 // Use the remote peer's UWB address
-                val peerAddress = UwbAddress(remoteConfig.uwbAddress)
-                val peerDevice = UwbDevice(peerAddress)
+                //val peerAddress = UwbAddress(remoteConfig.uwbAddress)
+                //val peerDevice = UwbDevice(peerAddress)
+                //Log.d(TAG, "device address is ${remoteConfig.uwbAddress.toHexString()}")
 
                 // Deterministic agreement without a handshake: the peer with the
                 // lexicographically smaller UWB address is the initiator, and both
                 // peers adopt its full parameter set (session ID, channel, preamble,
                 // and static-STS key). Both ends hold both configs after the BLE
                 // exchange, so they independently compute the same values.
+
+                // unless it's an accessory device, in which case we should always use the remoteConfig
                 val localConfig = getLocalConfig()
-                val agreed = if (localConfig != null &&
+                Log.d(TAG,"accessory=${remoteConfig.isAccessoryDevice}")
+                var agreed = if (localConfig != null && !remoteConfig.isAccessoryDevice &&
                     compareAddresses(localConfig.uwbAddress, remoteConfig.uwbAddress) <= 0
                 ) {
                     localConfig
@@ -132,21 +130,27 @@ actual class MultiplatformUwbManager(private val androidUwbManager: UwbManager? 
                     remoteConfig
                 }
 
-                val sessionKey = agreed.sessionKey
-                if (sessionKey == null || sessionKey.size != SESSION_KEY_SIZE) {
+                // don't use a local variable
+                if (agreed.sessionKey == null || agreed.sessionKey!!.size != SESSION_KEY_SIZE) {
                     errorCallback?.invoke(
                         "Cannot range with $peerId: missing or invalid session key " +
                                 "(static STS requires $SESSION_KEY_SIZE bytes)"
                     )
+                    Log.d(TAG, "no sessionKey set for ${agreed.uwbAddress.toHexString()}")
                     activeJobs.remove(peerId)
                     return@launch
                 }
+
+                // Use the remote peer's UWB address
+                val peerAddress = UwbAddress(agreed.uwbAddress)
+                val peerDevice = UwbDevice(peerAddress)
+                Log.d(TAG, "ranging peer device address is ${agreed.uwbAddress.toHexString()}")
 
                 val rangingParameters = RangingParameters(
                     uwbConfigType = RangingParameters.CONFIG_UNICAST_DS_TWR,
                     sessionId = agreed.sessionId,
                     subSessionId = 0,
-                    sessionKeyInfo = sessionKey,
+                    sessionKeyInfo = agreed.sessionKey,
                     subSessionKeyInfo = null,
                     complexChannel = UwbComplexChannel(
                         channel = agreed.channel,
@@ -158,16 +162,25 @@ actual class MultiplatformUwbManager(private val androidUwbManager: UwbManager? 
 
                 Log.d(
                     TAG,
-                    "Starting ranging with $peerId — session=${agreed.sessionId.toHexString()} ch=${agreed.channel}"
+                    "Starting ranging with $peerId — session=${agreed.sessionId.toHexString()} ch=${agreed.channel} address=${agreed.uwbAddress.toHexString()}"
                 )
+
+                // if this is an accessory, send the config it should use now, as we have done all the pre-checking
+                if(agreed.isAccessoryDevice) {
+                    val message = byteArrayOf(ANDROID_ACCESSORY_CONFIGURE_AND_START)+ localConfig?.toByteArray()!!
+                    Log.d(TAG, "sending config data message to accessory=${message.toHexString()}")
+                    localConfig.toByteArray().let { sendToPeerCallback?.invoke(peerId, message) }
+                }
 
                 scope.prepareSession(rangingParameters)
                     .catch { exception ->
                         errorCallback?.invoke("Ranging failed for $peerId: ${exception.message}")
                     }
                     .collect { result ->
+                        Log.d(TAG, "in collect")
                         when (result) {
                             is RangingResult.RangingResultPosition -> {
+                                Log.d(TAG,"Ranging position report")
                                 val distance = result.position.distance?.value
                                 if (distance != null) {
                                     rangingCallback?.invoke(
@@ -178,18 +191,26 @@ actual class MultiplatformUwbManager(private val androidUwbManager: UwbManager? 
                                     )
                                 }
                             }
-
+                            is RangingResult.RangingResultInitialized ->{
+                                Log.d(TAG,"Ranging init")
+                            }
                             is RangingResult.RangingResultPeerDisconnected -> {
+                                Log.d(TAG,"peer disconnected")
                                 errorCallback?.invoke("Peer $peerId disconnected")
                                 activeJobs.remove(peerId)
+                            }
+                            else ->{
+                                Log.d(TAG,"unexpected ranging result ${result}")
                             }
                         }
                     }
             } catch (e: Exception) {
+                Log.d(TAG,"Ranging startup failed, ${e.message}")
                 errorCallback?.invoke("Failed to start ranging with $peerId: ${e.message}")
             }
+            Log.d(TAG,"Ranging active (maybe)")
         }
-
+        Log.d(TAG,"Ranging process starting for peer ${peerId}")
         activeJobs[peerId] = job
     }
 

--- a/uwbmodule/src/commonMain/kotlin/BleManager.kt
+++ b/uwbmodule/src/commonMain/kotlin/BleManager.kt
@@ -5,6 +5,7 @@ package com.dustedrob.uwb
  * and UWB session configuration exchange via GATT.
  */
 expect class BleManager {
+
     /** Start scanning for nearby UWB-capable devices. */
     fun startScanning()
 

--- a/uwbmodule/src/commonMain/kotlin/DeviceDiscoveryManager.kt
+++ b/uwbmodule/src/commonMain/kotlin/DeviceDiscoveryManager.kt
@@ -238,11 +238,11 @@ class DeviceDiscoveryManager(
             if (peerId in exchangedPeers) return
             pendingExchanges.remove(peerId)
             exchangedPeers.add(peerId)
-            if (remoteConfig.accessoryData != null) accessoryPeers.add(peerId)
+            if (remoteConfig.isAccessoryDevice || remoteConfig.accessoryData!=null) accessoryPeers.add(peerId)
 
             emitEvent(
                 EventType.ConfigExchangeComplete, peerId,
-                "Config exchanged — session=${remoteConfig.sessionId.toHexString()} ch=${remoteConfig.channel}"
+                "Config exchanged — session=${remoteConfig.sessionId.toHexString()} ch=${remoteConfig.channel} addr=${remoteConfig.uwbAddress.toHexString()}"
             )
 
             // Ensure peer is in our device list and update with config info

--- a/uwbmodule/src/commonMain/kotlin/DeviceDiscoveryManager.kt
+++ b/uwbmodule/src/commonMain/kotlin/DeviceDiscoveryManager.kt
@@ -242,7 +242,7 @@ class DeviceDiscoveryManager(
 
             emitEvent(
                 EventType.ConfigExchangeComplete, peerId,
-                "Config exchanged — session=${remoteConfig.sessionId} ch=${remoteConfig.channel}"
+                "Config exchanged — session=${remoteConfig.sessionId.toHexString()} ch=${remoteConfig.channel}"
             )
 
             // Ensure peer is in our device list and update with config info

--- a/uwbmodule/src/commonMain/kotlin/UwbProfile.kt
+++ b/uwbmodule/src/commonMain/kotlin/UwbProfile.kt
@@ -108,10 +108,10 @@ val DEFAULT_PROFILES: List<UwbProfile> = listOf(LOCAL_PROFILE)
 
 /** Host -> accessory: initialize (request the accessory's configuration). */
 const val NI_ACCESSORY_INIT_COMMAND: Byte = 0x0A
-
+const val ANDROID_ACCESSORY_INIT_COMMAND: Byte = 0x1A
 /** Host -> accessory: configure and start ranging. */
 const val NI_ACCESSORY_CONFIGURE_AND_START: Byte = 0x0B
-
+const val ANDROID_ACCESSORY_CONFIGURE_AND_START: Byte = 0x1B
 /** Host -> accessory: stop ranging. */
 const val NI_ACCESSORY_STOP: Byte = 0x0C
 

--- a/uwbmodule/src/commonMain/kotlin/UwbSessionConfig.kt
+++ b/uwbmodule/src/commonMain/kotlin/UwbSessionConfig.kt
@@ -32,6 +32,8 @@ data class UwbSessionConfig(
      * BLE layer wraps the accessory's raw payload in this field locally — it is not our own envelope.
      */
     val accessoryData: ByteArray? = null,
+    // indicates if this was created by accessory device info (android)
+    val isAccessoryDevice: Boolean = false,
 ) {
     /**
      * Serialize to a simple binary format for BLE GATT exchange.
@@ -133,7 +135,7 @@ data class UwbSessionConfig(
     companion object {
         private const val PROTOCOL_VERSION: Byte = 1
 
-        fun fromByteArray(bytes: ByteArray): UwbSessionConfig? {
+        fun fromByteArray(bytes: ByteArray, accessoryDevice: Boolean= false, accessoryData:ByteArray? = null): UwbSessionConfig? {
             if (bytes.size < 17) return null // minimum: 1(ver) + 4(sid) + 4(ch) + 4(pre) + 2(addrLen) + 2(tokLen)
             var pos = 0
 
@@ -179,6 +181,7 @@ data class UwbSessionConfig(
                 discoveryToken = discoveryToken,
                 sessionKey = sessionKey,
                 accessoryData = accessoryData,
+                isAccessoryDevice = accessoryDevice
             )
         }
 

--- a/uwbmodule/src/commonMain/kotlin/UwbSessionConfig.kt
+++ b/uwbmodule/src/commonMain/kotlin/UwbSessionConfig.kt
@@ -8,7 +8,7 @@ package com.dustedrob.uwb
  */
 data class UwbSessionConfig(
     /** Agreed-upon session identifier. Both peers must use the same value. */
-    val sessionId: Int,
+    var sessionId: Int,
     /** UWB channel number (e.g., 9). */
     val channel: Int,
     /** Preamble index for the UWB channel (e.g., 10). */
@@ -23,7 +23,7 @@ data class UwbSessionConfig(
      * Required by androidx.core.uwb for `CONFIG_UNICAST_DS_TWR`; both peers must
      * use the same key. Exchanged here so the two ends can agree on one.
      */
-    val sessionKey: ByteArray? = null,
+    var sessionKey: ByteArray? = null,
     /**
      * Opaque Apple/Qorvo Nearby-Interaction **Accessory Configuration Data** (iOS accessory) or null.
      *

--- a/uwbmodule/src/iosMain/kotlin/BleManager.kt
+++ b/uwbmodule/src/iosMain/kotlin/BleManager.kt
@@ -150,6 +150,7 @@ actual class BleManager(
             NSLog("BleManager: Connected to $deviceId, discovering services")
             didConnectPeripheral.delegate = peripheralClientDelegate
             didConnectPeripheral.discoverServices(null)
+            didConnectPeripheral.maximumWriteValueLengthForType(64)
         }
 
         // Note: didFailToConnect and didDisconnect omitted to avoid ObjC selector conflicts


### PR DESCRIPTION
misc changes here and there
MTU
the ID for the two Android specific messages to the accessory
init and configure_and _start

changed displayed session, and log info to use hex form 
changed UWBSessionConfig two vars to allow change, maybe should have changed how the agreed agreed config is built, can't just pick one or the other without synching the important fields.
sessionId and sessionKey have to be the same on both ends

Android deliverAccessory sends the localConfig to the remote after config_and_exchange returns.
(in ios this is done by the didGenerate callback)

both sides think ranging is active, but not returning any info, so we might have other config issues.. 
I'm working them in a sep issue #37
I think this closes #31 