### PR TITLE
Add inline per-device direction arrow from ranging data

### DIFF
--- a/composeApp/src/commonMain/kotlin/App.kt
+++ b/composeApp/src/commonMain/kotlin/App.kt
@@ -1,3 +1,4 @@
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -31,9 +32,17 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.drawscope.rotate
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import kotlin.math.PI
+import kotlin.math.cos
+import org.jetbrains.compose.ui.tooling.preview.Preview
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.dustedrob.uwb.DeviceState
 import com.dustedrob.uwb.DiscoveryEvent
@@ -229,16 +238,76 @@ private fun DeviceItem(device: NearbyDevice) {
                 }
             }
 
-            if (device.distance != null) {
-                val distStr = device.distance.toString()
-                val dotIdx = distStr.indexOf('.')
-                val formatted = if (dotIdx >= 0 && dotIdx + 3 < distStr.length) distStr.substring(0, dotIdx + 3) else distStr
-                Text(
-                    text = "${formatted}m",
-                    style = MaterialTheme.typography.h6,
-                    color = Color(0xFF4CAF50)
-                )
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                if (device.state == DeviceState.Ranging) {
+                    DirectionArrow(
+                        azimuthDeg = device.azimuth,
+                        elevationDeg = device.elevation,
+                        modifier = Modifier.size(48.dp)
+                    )
+                }
+                val dist = device.distance
+                if (dist != null) {
+                    Text(
+                        text = "${formatMeters(dist)}m",
+                        style = MaterialTheme.typography.subtitle1,
+                        color = Color(0xFF4CAF50)
+                    )
+                }
             }
+        }
+    }
+}
+
+/** Trims a distance in meters to 2 decimal places without pulling in platform formatting. */
+private fun formatMeters(meters: Double): String {
+    val s = meters.toString()
+    val dot = s.indexOf('.')
+    return if (dot >= 0 && dot + 3 < s.length) s.substring(0, dot + 3) else s
+}
+
+/**
+ * A small compass that draws an arrow pointing toward a ranging peer.
+ *
+ * [azimuthDeg] rotates the arrow (0 = straight ahead, positive = to the right) and
+ * [elevationDeg] foreshortens it (larger angle = shorter, i.e. more above/below than ahead).
+ * Both are in degrees. When [azimuthDeg] is `null` (direction not resolved yet) only the ring
+ * is drawn, so a card never looks broken while direction is still converging.
+ */
+@Composable
+private fun DirectionArrow(
+    azimuthDeg: Double?,
+    elevationDeg: Double?,
+    modifier: Modifier = Modifier,
+) {
+    val arrowColor = MaterialTheme.colors.primary
+    Canvas(modifier = modifier) {
+        val center = Offset(size.width / 2f, size.height / 2f)
+        val radius = size.minDimension / 2f * 0.85f
+
+        drawCircle(color = Color.LightGray, radius = radius, center = center, style = Stroke(width = 2f))
+
+        if (azimuthDeg == null) return@Canvas
+
+        val elevScale = elevationDeg?.let { cos(it * PI / 180.0).toFloat() } ?: 1f
+        val len = radius * elevScale
+
+        rotate(degrees = azimuthDeg.toFloat(), pivot = center) {
+            val tip = Offset(center.x, center.y - len)
+            drawLine(
+                color = arrowColor,
+                start = center,
+                end = tip,
+                strokeWidth = 4f,
+                cap = StrokeCap.Round
+            )
+            val head = Path().apply {
+                moveTo(tip.x, tip.y)
+                lineTo(tip.x - 7f, tip.y + 11f)
+                lineTo(tip.x + 7f, tip.y + 11f)
+                close()
+            }
+            drawPath(head, arrowColor)
         }
     }
 }
@@ -264,4 +333,107 @@ private fun EventLogItem(event: DiscoveryEvent) {
         color = color,
         modifier = Modifier.padding(vertical = 1.dp)
     )
+}
+
+// ---------------------------------------------------------------------------
+// Previews
+// ---------------------------------------------------------------------------
+
+@Preview
+@Composable
+private fun DirectionArrowPreview() {
+    Row(
+        modifier = Modifier.background(Color.White).padding(12.dp),
+        horizontalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        // Straight ahead
+        DirectionArrow(azimuthDeg = 0.0, elevationDeg = 0.0, modifier = Modifier.size(64.dp))
+        // 45° to the right
+        DirectionArrow(azimuthDeg = 45.0, elevationDeg = 0.0, modifier = Modifier.size(64.dp))
+        // To the left and tilted up (foreshortened)
+        DirectionArrow(azimuthDeg = -60.0, elevationDeg = 40.0, modifier = Modifier.size(64.dp))
+        // Direction not resolved yet — ring only
+        DirectionArrow(azimuthDeg = null, elevationDeg = null, modifier = Modifier.size(64.dp))
+    }
+}
+
+@Preview
+@Composable
+private fun DeviceItemPreview() {
+    Column(
+        modifier = Modifier.background(Color(0xFFFAFAFA)).padding(8.dp),
+        verticalArrangement = Arrangement.spacedBy(4.dp)
+    ) {
+        // Ranging with resolved direction
+        DeviceItem(
+            NearbyDevice(
+                id = "AA:BB:CC:DD:EE:FF",
+                name = "Qorvo DWM3001",
+                distance = 1.234,
+                azimuth = 30.0,
+                elevation = 10.0,
+                state = DeviceState.Ranging,
+                sessionId = 42,
+                channel = 9,
+            )
+        )
+        // Ranging but direction not yet available
+        DeviceItem(
+            NearbyDevice(
+                id = "11:22:33:44:55:66",
+                name = "Pixel 8 Pro",
+                distance = 3.5,
+                azimuth = null,
+                elevation = null,
+                state = DeviceState.Ranging,
+                sessionId = 7,
+                channel = 9,
+            )
+        )
+        // Just discovered
+        DeviceItem(
+            NearbyDevice(
+                id = "77:88:99:AA:BB:CC",
+                name = "Unknown Device",
+                state = DeviceState.Discovered,
+            )
+        )
+        // Error state
+        DeviceItem(
+            NearbyDevice(
+                id = "DE:AD:BE:EF:00:11",
+                name = "Flaky Accessory",
+                state = DeviceState.Error,
+                errorMessage = "Peer disconnected",
+            )
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun LocalDeviceInfoPreview() {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        LocalDeviceInfo(
+            config = UwbSessionConfig(
+                sessionId = 42,
+                channel = 9,
+                preambleIndex = 10,
+                uwbAddress = byteArrayOf(0x0A, 0x1B, 0x2C, 0x3D),
+            ),
+            isScanning = true,
+        )
+        LocalDeviceInfo(config = null, isScanning = false)
+    }
+}
+
+@Preview
+@Composable
+private fun EventLogItemPreview() {
+    Column(modifier = Modifier.background(Color(0xFFF5F5F5)).padding(4.dp)) {
+        EventLogItem(DiscoveryEvent(0L, EventType.DeviceDiscovered, "peer", "Discovered nearby device"))
+        EventLogItem(DiscoveryEvent(0L, EventType.RangingStarted, "peer", "Ranging started"))
+        EventLogItem(DiscoveryEvent(0L, EventType.ConfigExchangeComplete, "peer", "Config exchange complete"))
+        EventLogItem(DiscoveryEvent(0L, EventType.Error, "peer", "Something went wrong"))
+    }
 }

--- a/uwbmodule/src/commonMain/kotlin/NearbyDevice.kt
+++ b/uwbmodule/src/commonMain/kotlin/NearbyDevice.kt
@@ -17,6 +17,10 @@ enum class DeviceState {
  * @property id Unique identifier (BLE address on Android, peripheral UUID on iOS).
  * @property name Human-readable device name from the BLE advertisement.
  * @property distance Current UWB-measured distance in meters, or `null` if not yet ranging.
+ * @property azimuth Horizontal angle to the device in degrees (0 = straight ahead, positive = right),
+ *   or `null` if direction isn't available yet.
+ * @property elevation Vertical angle to the device in degrees (positive = above), or `null` if
+ *   unavailable. Always `null` on iOS — NearbyInteraction reports no elevation measurement.
  * @property lastSeen Epoch millis when the device was last observed or ranged.
  * @property state Current connection state in the discovery pipeline.
  * @property errorMessage Error description if [state] is [DeviceState.Error].

--- a/uwbmodule/src/iosMain/kotlin/MultiplatformUwbManager.ios.kt
+++ b/uwbmodule/src/iosMain/kotlin/MultiplatformUwbManager.ios.kt
@@ -1,5 +1,6 @@
 package com.dustedrob.uwb
 
+import kotlin.math.PI
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.useContents
 import platform.Foundation.NSData
@@ -224,10 +225,14 @@ actual class MultiplatformUwbManager {
                                 ?: accessoryPeerId ?: "unknown"
 
                             // Azimuth (`horizontalAngle`) is iOS 16+ and is NaN until camera-assistance
-                            // convergence, so only emit it when available and valid.
+                            // convergence, so only emit it when available and valid. NearbyInteraction
+                            // reports it in radians; convert to degrees to match the module contract
+                            // (Android reports degrees), so consumers get one consistent unit.
                             val azimuth: Double? =
                                 if (directionApiAvailable) {
-                                    obj.horizontalAngle.let { if (it.isNaN()) null else it.toDouble() }
+                                    obj.horizontalAngle.let {
+                                        if (it.isNaN()) null else it.toDouble() * 180.0 / PI
+                                    }
                                 } else {
                                     null
                                 }


### PR DESCRIPTION
Addresses #12 — adds a canvas-drawn arrow to the UI so each ranging device shows which way it is, built from the azimuth/elevation already in the ranging data.

## What's here
- **`DirectionArrow` composable** — a Compose `Canvas` compass that rotates the arrow by `azimuth` and foreshortens it by `elevation`. When direction hasn't resolved yet it draws just the ring, so a card never looks broken while direction is converging.
- **Inline in each `DeviceItem`** — a compact 48dp arrow over the distance, shown only for devices in the `Ranging` state.
- **iOS unit fix** — `horizontalAngle` is now converted from radians to degrees so `NearbyDevice.azimuth` is degrees on both platforms (Android already reported degrees). Without this the iOS arrows would point wrong.
- **Docs** — documented the azimuth/elevation units on `NearbyDevice`, including that elevation is always `null` on iOS (NearbyInteraction has no elevation measurement).
- **`@Preview`s** for `DirectionArrow`, `DeviceItem`, `LocalDeviceInfo`, and `EventLogItem`.

<img width="1145" height="832" alt="image" src="https://github.com/user-attachments/assets/adcaf12f-0e2e-4d87-96ee-deba78a0e8f4" />



## Verification
- `:composeApp:compileDebugKotlinAndroid` and `:composeApp:compileKotlinIosArm64` both build (JBR 17).
- Not yet run on a device, so arrow sizing and the azimuth sign convention (positive = right) may need tuning once seen live.
