### PR TITLE
UwbSessionConfig: little-endian wire format to match FiRa convention

### DIFF
--- a/uwbmodule/src/commonMain/kotlin/UwbSessionConfig.kt
+++ b/uwbmodule/src/commonMain/kotlin/UwbSessionConfig.kt
@@ -38,7 +38,7 @@ data class UwbSessionConfig(
     /**
      * Serialize to a simple binary format for BLE GATT exchange.
      *
-     * Format (big-endian):
+     * Format (little-endian):
      * ```
      * [1B version][4B sessionId][4B channel][4B preambleIndex]
      * [2B uwbAddr.size][uwbAddr bytes]
@@ -46,7 +46,11 @@ data class UwbSessionConfig(
      * [2B key.size][key bytes]       // optional trailer; absent or size=0 if null
      * [2B acc.size][acc bytes]       // optional trailer; absent or size=0 if null
      * ```
-     * The session-key and accessory-data trailers are optional so older payloads still parse.
+     * Multi-byte integers (sessionId, channel, preambleIndex, and the 2-byte length prefixes) are
+     * little-endian to match the FiRa/UWB convention, so accessory firmware can lay the struct out
+     * natively without byte-swapping. The byte-array fields (address, token, key) are opaque and are
+     * copied verbatim. The session-key and accessory-data trailers are optional so older/shorter
+     * payloads still parse.
      */
     fun toByteArray(): ByteArray {
         val tokenBytes = discoveryToken ?: ByteArray(0)
@@ -59,45 +63,45 @@ data class UwbSessionConfig(
         // Version
         buf[pos++] = PROTOCOL_VERSION
 
-        // sessionId
-        buf[pos++] = (sessionId shr 24).toByte()
-        buf[pos++] = (sessionId shr 16).toByte()
-        buf[pos++] = (sessionId shr 8).toByte()
+        // sessionId (LE)
         buf[pos++] = sessionId.toByte()
+        buf[pos++] = (sessionId shr 8).toByte()
+        buf[pos++] = (sessionId shr 16).toByte()
+        buf[pos++] = (sessionId shr 24).toByte()
 
-        // channel
-        buf[pos++] = (channel shr 24).toByte()
-        buf[pos++] = (channel shr 16).toByte()
-        buf[pos++] = (channel shr 8).toByte()
+        // channel (LE)
         buf[pos++] = channel.toByte()
+        buf[pos++] = (channel shr 8).toByte()
+        buf[pos++] = (channel shr 16).toByte()
+        buf[pos++] = (channel shr 24).toByte()
 
-        // preambleIndex
-        buf[pos++] = (preambleIndex shr 24).toByte()
-        buf[pos++] = (preambleIndex shr 16).toByte()
-        buf[pos++] = (preambleIndex shr 8).toByte()
+        // preambleIndex (LE)
         buf[pos++] = preambleIndex.toByte()
+        buf[pos++] = (preambleIndex shr 8).toByte()
+        buf[pos++] = (preambleIndex shr 16).toByte()
+        buf[pos++] = (preambleIndex shr 24).toByte()
 
         // uwbAddress
-        buf[pos++] = (uwbAddress.size shr 8).toByte()
         buf[pos++] = uwbAddress.size.toByte()
+        buf[pos++] = (uwbAddress.size shr 8).toByte()
         uwbAddress.copyInto(buf, pos)
         pos += uwbAddress.size
 
         // discoveryToken
-        buf[pos++] = (tokenBytes.size shr 8).toByte()
         buf[pos++] = tokenBytes.size.toByte()
+        buf[pos++] = (tokenBytes.size shr 8).toByte()
         tokenBytes.copyInto(buf, pos)
         pos += tokenBytes.size
 
         // sessionKey
-        buf[pos++] = (keyBytes.size shr 8).toByte()
         buf[pos++] = keyBytes.size.toByte()
+        buf[pos++] = (keyBytes.size shr 8).toByte()
         keyBytes.copyInto(buf, pos)
         pos += keyBytes.size
 
         // accessoryData
-        buf[pos++] = (accBytes.size shr 8).toByte()
         buf[pos++] = accBytes.size.toByte()
+        buf[pos++] = (accBytes.size shr 8).toByte()
         accBytes.copyInto(buf, pos)
 
         return buf
@@ -185,14 +189,15 @@ data class UwbSessionConfig(
             )
         }
 
+        // Little-endian readers (least-significant byte first), matching toByteArray.
         private fun readInt(bytes: ByteArray, offset: Int): Int =
-            ((bytes[offset].toInt() and 0xFF) shl 24) or
-                    ((bytes[offset + 1].toInt() and 0xFF) shl 16) or
-                    ((bytes[offset + 2].toInt() and 0xFF) shl 8) or
-                    (bytes[offset + 3].toInt() and 0xFF)
+            (bytes[offset].toInt() and 0xFF) or
+                    ((bytes[offset + 1].toInt() and 0xFF) shl 8) or
+                    ((bytes[offset + 2].toInt() and 0xFF) shl 16) or
+                    ((bytes[offset + 3].toInt() and 0xFF) shl 24)
 
         private fun readShort(bytes: ByteArray, offset: Int): Int =
-            ((bytes[offset].toInt() and 0xFF) shl 8) or
-                    (bytes[offset + 1].toInt() and 0xFF)
+            (bytes[offset].toInt() and 0xFF) or
+                    ((bytes[offset + 1].toInt() and 0xFF) shl 8)
     }
 }

--- a/uwbmodule/src/commonTest/kotlin/com/dustedrob/uwb/UwbSessionConfigTest.kt
+++ b/uwbmodule/src/commonTest/kotlin/com/dustedrob/uwb/UwbSessionConfigTest.kt
@@ -139,26 +139,55 @@ class UwbSessionConfigTest {
     }
 
     @Test
-    fun parsesLegacyPayloadWithoutKeyTrailer() {
-        // A payload from before the session-key trailer existed: it ends right after
-        // the discovery-token block, with no [2B key.size] trailer at all.
+    fun parsesShortPayloadWithoutKeyTrailer() {
+        // A minimal payload that ends right after the discovery-token block, with no [2B key.size]
+        // trailer at all. Bytes are little-endian (LSB first), matching the wire format.
         val sid = 42
         val ch = 9
         val pre = 10
         val addr = byteArrayOf(0x01, 0x02)
-        val legacy = byteArrayOf(
+        val short = byteArrayOf(
             1, // version
-            (sid shr 24).toByte(), (sid shr 16).toByte(), (sid shr 8).toByte(), sid.toByte(),
-            (ch shr 24).toByte(), (ch shr 16).toByte(), (ch shr 8).toByte(), ch.toByte(),
-            (pre shr 24).toByte(), (pre shr 16).toByte(), (pre shr 8).toByte(), pre.toByte(),
-            (addr.size shr 8).toByte(), addr.size.toByte(), addr[0], addr[1],
+            sid.toByte(), (sid shr 8).toByte(), (sid shr 16).toByte(), (sid shr 24).toByte(),
+            ch.toByte(), (ch shr 8).toByte(), (ch shr 16).toByte(), (ch shr 24).toByte(),
+            pre.toByte(), (pre shr 8).toByte(), (pre shr 16).toByte(), (pre shr 24).toByte(),
+            addr.size.toByte(), (addr.size shr 8).toByte(), addr[0], addr[1],
             0, 0, // token size = 0
         )
-        val restored = UwbSessionConfig.fromByteArray(legacy)
+        val restored = UwbSessionConfig.fromByteArray(short)
         assertNotNull(restored)
         assertEquals(sid, restored.sessionId)
         assertNull(restored.sessionKey)
         assertNull(restored.accessoryData)
+    }
+
+    @Test
+    fun serializesMultiByteFieldsLittleEndian() {
+        // Pins the wire contract: multi-byte integers are little-endian (LSB first) so accessory
+        // firmware can lay out its FiRa struct natively (session_id = 0x691A4B22, channel = 9,
+        // preamble = 10, address_size = 2) without byte-swapping.
+        val config = UwbSessionConfig(
+            sessionId = 0x691A4B22,
+            channel = 9,
+            preambleIndex = 10,
+            uwbAddress = byteArrayOf(0x02, 0xC9.toByte()),
+        )
+        val b = config.toByteArray()
+        assertEquals(1.toByte(), b[0]) // version
+        // sessionId 0x691A4B22 -> 22 4B 1A 69
+        assertEquals(0x22.toByte(), b[1]); assertEquals(0x4B.toByte(), b[2])
+        assertEquals(0x1A.toByte(), b[3]); assertEquals(0x69.toByte(), b[4])
+        // channel 9 -> 09 00 00 00
+        assertEquals(0x09.toByte(), b[5]); assertEquals(0.toByte(), b[6])
+        assertEquals(0.toByte(), b[7]); assertEquals(0.toByte(), b[8])
+        // preambleIndex 10 -> 0A 00 00 00
+        assertEquals(0x0A.toByte(), b[9]); assertEquals(0.toByte(), b[10])
+        assertEquals(0.toByte(), b[11]); assertEquals(0.toByte(), b[12])
+        // address size 2 -> 02 00, then the 2 address bytes verbatim
+        assertEquals(0x02.toByte(), b[13]); assertEquals(0.toByte(), b[14])
+        assertEquals(0x02.toByte(), b[15]); assertEquals(0xC9.toByte(), b[16])
+        // and it round-trips
+        assertEquals(config, UwbSessionConfig.fromByteArray(b))
     }
 
     @Test


### PR DESCRIPTION
Flips the `UwbSessionConfig` binary format from big-endian to little-endian so it matches the FiRa/UWB convention that accessory firmware naturally uses.

## Why
The current serialization is big-endian, but FiRa/UWB lays multi-byte fields out little-endian. That mismatch is why the Qorvo accessory firmware (see #31) had to compensate with byte-swap hacks like `channel = 0x09000000`, `address_size = 512`, and manually reversed address bytes just to be read correctly by our parser. With a little-endian format, a firmware author can lay the struct out natively (`channel = 9`, `address_size = 2`, address in order) with no workarounds, so the Android-accessory protocol becomes portable to other hardware instead of tied to one patched binary.

## What changed
- `toByteArray()` writes `sessionId`, `channel`, `preambleIndex`, and the 2-byte length prefixes least-significant-byte first. Byte-array fields (address, token, key) are opaque and still copied verbatim.
- `readInt` / `readShort` read little-endian to match.
- Added `serializesMultiByteFieldsLittleEndian` which pins the exact byte layout (using the same `0x691A4B22` / addr `02 C9` example from #31), plus updated the short-payload test to LE bytes.

## Compatibility
Phone-to-phone is unaffected: both ends serialize and deserialize with this same code, so the round-trip is symmetric (existing round-trip tests still pass, both Android and iOS). The change only matters at the firmware boundary, which is exactly where we want it to be spec-correct. Note this is a wire-format change, so both peers must run the same build to interop, and accessory firmware should be updated to plain little-endian.

Relates to #31 and the accessory-ranging work in #45.
