### PR TITLE
Request UWB_RANGING runtime permission on Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,15 @@ Add required permissions to `AndroidManifest.xml`:
 <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 ```
 
+> **Runtime permissions are the app's responsibility.** Declaring these in the manifest is not
+> enough — `BLUETOOTH_SCAN`, `BLUETOOTH_ADVERTISE`, `BLUETOOTH_CONNECT`, and `UWB_RANGING` are
+> runtime ("dangerous") permissions that the app must request from the user before scanning or
+> ranging. Note that `UWB_RANGING` (API 31+) is a **separate** permission that is *not* part of the
+> "Nearby devices" group, so granting the Bluetooth permissions does not grant it; without it,
+> ranging fails with `SecurityException: Caller does not hold UWB_RANGING permission`. moko-permissions
+> does not model `UWB_RANGING`, so request it via the platform API. See `Permissions.android.kt` and
+> `UwbDiscoveryViewModel.checkAndRequestPermissions()` in the sample app for a working example.
+
 ### iOS Configuration
 
 Add required permissions to `Info.plist`:

--- a/composeApp/src/androidMain/kotlin/Permissions.android.kt
+++ b/composeApp/src/androidMain/kotlin/Permissions.android.kt
@@ -1,0 +1,48 @@
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.activity.ComponentActivity
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.content.ContextCompat
+import kotlinx.coroutines.CompletableDeferred
+
+/**
+ * Registers and drives the Android `UWB_RANGING` runtime permission request.
+ *
+ * [register] must be called from the host Activity's `onCreate` (before it is STARTED) so the
+ * result launcher is valid. moko-permissions has no `UWB_RANGING` type, so this is requested
+ * through the platform API directly.
+ */
+object UwbRangingPermission {
+    private var appContext: Context? = null
+    private var launcher: ActivityResultLauncher<String>? = null
+    private var pending: CompletableDeferred<Boolean>? = null
+
+    fun register(activity: ComponentActivity) {
+        appContext = activity.applicationContext
+        launcher = activity.registerForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
+            pending?.complete(granted)
+            pending = null
+        }
+    }
+
+    private fun isGranted(context: Context): Boolean =
+        ContextCompat.checkSelfPermission(context, Manifest.permission.UWB_RANGING) ==
+            PackageManager.PERMISSION_GRANTED
+
+    suspend fun ensure(): Boolean {
+        // UWB_RANGING did not exist before API 31; nothing to request.
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return true
+        val context = appContext ?: return false
+        if (isGranted(context)) return true
+        val l = launcher ?: return isGranted(context)
+        val deferred = CompletableDeferred<Boolean>()
+        pending = deferred
+        l.launch(Manifest.permission.UWB_RANGING)
+        return deferred.await()
+    }
+}
+
+actual suspend fun ensureUwbRangingPermission(): Boolean = UwbRangingPermission.ensure()

--- a/composeApp/src/androidMain/kotlin/com/dustedrob/multiplatformuwb/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/com/dustedrob/multiplatformuwb/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.dustedrob.multiplatformuwb
 
 import App
+import UwbRangingPermission
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -11,6 +12,9 @@ import androidx.compose.ui.tooling.preview.Preview
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        // Register the UWB_RANGING permission launcher before the activity is STARTED.
+        UwbRangingPermission.register(this)
 
         setContent {
             App()

--- a/composeApp/src/commonMain/kotlin/Permissions.kt
+++ b/composeApp/src/commonMain/kotlin/Permissions.kt
@@ -1,0 +1,10 @@
+/**
+ * Ensures the Android `UWB_RANGING` runtime permission is granted, prompting the user if needed.
+ *
+ * `UWB_RANGING` (API 31+) is a separate "dangerous" permission and is NOT part of the "Nearby
+ * devices" group, so it must be requested on its own. moko-permissions doesn't model it, which is
+ * why ranging fails with `SecurityException: Caller does not hold UWB_RANGING permission` even when
+ * the Bluetooth permissions are granted. Returns true on iOS (no equivalent) and on Android below
+ * API 31 (the permission doesn't exist there).
+ */
+expect suspend fun ensureUwbRangingPermission(): Boolean

--- a/composeApp/src/commonMain/kotlin/UwbDiscoveryViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/UwbDiscoveryViewModel.kt
@@ -89,6 +89,11 @@ class UwbDiscoveryViewModel(
             controller.providePermission(Permission.BLUETOOTH_SCAN)
             controller.providePermission(Permission.BLUETOOTH_ADVERTISE)
             controller.providePermission(Permission.BLUETOOTH_CONNECT)
+            // UWB_RANGING is a separate runtime permission not covered by moko / "Nearby devices".
+            if (!ensureUwbRangingPermission()) {
+                permissionState = PermissionState.Denied
+                return false
+            }
             permissionState = PermissionState.Granted
             true
         } catch (e: DeniedAlwaysException) {

--- a/composeApp/src/iosMain/kotlin/Permissions.ios.kt
+++ b/composeApp/src/iosMain/kotlin/Permissions.ios.kt
@@ -1,0 +1,3 @@
+// iOS has no UWB_RANGING permission (Nearby Interaction is gated by NSNearbyInteractionUsageDescription),
+// so there is nothing to request here.
+actual suspend fun ensureUwbRangingPermission(): Boolean = true


### PR DESCRIPTION
Fixes the `SecurityException: Caller does not hold UWB_RANGING permission` hit in #46 even with "Nearby devices" granted.

`UWB_RANGING` (API 31+) is a separate dangerous permission, not part of the Nearby-devices group. It was declared in the manifest but never requested at runtime, so it stayed denied until manually `adb pm grant`-ed. moko-permissions doesn't model it, so this requests it via the platform API:

- `expect/actual ensureUwbRangingPermission()` — Android prompts via an `ActivityResultContracts.RequestPermission` launcher (registered in MainActivity.onCreate, gated to API 31+); iOS returns true (no equivalent).
- Wired into the ViewModel's permission flow after the Bluetooth permissions.
