### PR TITLE
first pass at Multi session

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,15 @@ Add required permissions to `AndroidManifest.xml`:
 <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 ```
 
+> **Runtime permissions are the app's responsibility.** Declaring these in the manifest is not
+> enough — `BLUETOOTH_SCAN`, `BLUETOOTH_ADVERTISE`, `BLUETOOTH_CONNECT`, and `UWB_RANGING` are
+> runtime ("dangerous") permissions that the app must request from the user before scanning or
+> ranging. Note that `UWB_RANGING` (API 31+) is a **separate** permission that is *not* part of the
+> "Nearby devices" group, so granting the Bluetooth permissions does not grant it; without it,
+> ranging fails with `SecurityException: Caller does not hold UWB_RANGING permission`. moko-permissions
+> does not model `UWB_RANGING`, so request it via the platform API. See `Permissions.android.kt` and
+> `UwbDiscoveryViewModel.checkAndRequestPermissions()` in the sample app for a working example.
+
 ### iOS Configuration
 
 Add required permissions to `Info.plist`:

--- a/composeApp/src/androidMain/kotlin/Permissions.android.kt
+++ b/composeApp/src/androidMain/kotlin/Permissions.android.kt
@@ -1,0 +1,48 @@
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.activity.ComponentActivity
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.content.ContextCompat
+import kotlinx.coroutines.CompletableDeferred
+
+/**
+ * Registers and drives the Android `UWB_RANGING` runtime permission request.
+ *
+ * [register] must be called from the host Activity's `onCreate` (before it is STARTED) so the
+ * result launcher is valid. moko-permissions has no `UWB_RANGING` type, so this is requested
+ * through the platform API directly.
+ */
+object UwbRangingPermission {
+    private var appContext: Context? = null
+    private var launcher: ActivityResultLauncher<String>? = null
+    private var pending: CompletableDeferred<Boolean>? = null
+
+    fun register(activity: ComponentActivity) {
+        appContext = activity.applicationContext
+        launcher = activity.registerForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
+            pending?.complete(granted)
+            pending = null
+        }
+    }
+
+    private fun isGranted(context: Context): Boolean =
+        ContextCompat.checkSelfPermission(context, Manifest.permission.UWB_RANGING) ==
+            PackageManager.PERMISSION_GRANTED
+
+    suspend fun ensure(): Boolean {
+        // UWB_RANGING did not exist before API 31; nothing to request.
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return true
+        val context = appContext ?: return false
+        if (isGranted(context)) return true
+        val l = launcher ?: return isGranted(context)
+        val deferred = CompletableDeferred<Boolean>()
+        pending = deferred
+        l.launch(Manifest.permission.UWB_RANGING)
+        return deferred.await()
+    }
+}
+
+actual suspend fun ensureUwbRangingPermission(): Boolean = UwbRangingPermission.ensure()

--- a/composeApp/src/androidMain/kotlin/com/dustedrob/multiplatformuwb/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/com/dustedrob/multiplatformuwb/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.dustedrob.multiplatformuwb
 
 import App
+import UwbRangingPermission
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -11,6 +12,9 @@ import androidx.compose.ui.tooling.preview.Preview
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        // Register the UWB_RANGING permission launcher before the activity is STARTED.
+        UwbRangingPermission.register(this)
 
         setContent {
             App()

--- a/composeApp/src/commonMain/kotlin/App.kt
+++ b/composeApp/src/commonMain/kotlin/App.kt
@@ -171,7 +171,7 @@ private fun LocalDeviceInfo(config: UwbSessionConfig?, isScanning: Boolean) {
                     (byte.toInt() and 0xFF).toString(16).padStart(2, '0').uppercase()
                 }
                 Text("UWB Address: $addrHex", style = MaterialTheme.typography.caption)
-                Text("Session ID: ${config.sessionId.toHexString()}  Channel: ${config.channel}", style = MaterialTheme.typography.caption)
+                Text("Session ID: ${config.sessionId?.toHexString()}  Channel: ${config.channel}", style = MaterialTheme.typography.caption)
             } else {
                 Text(
                     if (isScanning) "Initializing UWB…" else "Not started",

--- a/composeApp/src/commonMain/kotlin/Permissions.kt
+++ b/composeApp/src/commonMain/kotlin/Permissions.kt
@@ -1,0 +1,10 @@
+/**
+ * Ensures the Android `UWB_RANGING` runtime permission is granted, prompting the user if needed.
+ *
+ * `UWB_RANGING` (API 31+) is a separate "dangerous" permission and is NOT part of the "Nearby
+ * devices" group, so it must be requested on its own. moko-permissions doesn't model it, which is
+ * why ranging fails with `SecurityException: Caller does not hold UWB_RANGING permission` even when
+ * the Bluetooth permissions are granted. Returns true on iOS (no equivalent) and on Android below
+ * API 31 (the permission doesn't exist there).
+ */
+expect suspend fun ensureUwbRangingPermission(): Boolean

--- a/composeApp/src/commonMain/kotlin/UwbDiscoveryViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/UwbDiscoveryViewModel.kt
@@ -118,6 +118,7 @@ class UwbDiscoveryViewModel(
 
     override fun onCleared() {
         super.onCleared()
-        //deviceDiscoveryManager.cleanup()
+        //deviceDiscoveryManager.cleanup()   <--- can't make this suspend..
+
     }
 }

--- a/composeApp/src/commonMain/kotlin/UwbDiscoveryViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/UwbDiscoveryViewModel.kt
@@ -89,6 +89,11 @@ class UwbDiscoveryViewModel(
             controller.providePermission(Permission.BLUETOOTH_SCAN)
             controller.providePermission(Permission.BLUETOOTH_ADVERTISE)
             controller.providePermission(Permission.BLUETOOTH_CONNECT)
+            // UWB_RANGING is a separate runtime permission not covered by moko / "Nearby devices".
+            if (!ensureUwbRangingPermission()) {
+                permissionState = PermissionState.Denied
+                return false
+            }
             permissionState = PermissionState.Granted
             true
         } catch (e: DeniedAlwaysException) {

--- a/composeApp/src/commonMain/kotlin/UwbDiscoveryViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/UwbDiscoveryViewModel.kt
@@ -31,7 +31,7 @@ class UwbDiscoveryViewModel(
         managerFactory.createUwbManager(),
         // Phone-to-phone over LOCAL_PROFILE; also scan for the Qorvo accessory (app-owned profile).
         managerFactory.createBleManager(
-            BleDiscoveryConfig(profiles = listOf(LOCAL_PROFILE,  QorvoNearbyProfile,  CNCustom))
+            BleDiscoveryConfig(profiles = listOf(LOCAL_PROFILE,  QorvoNearbyProfile))
         )
     )
     var permissionState by mutableStateOf(PermissionState.NotDetermined)

--- a/composeApp/src/iosMain/kotlin/Permissions.ios.kt
+++ b/composeApp/src/iosMain/kotlin/Permissions.ios.kt
@@ -1,0 +1,3 @@
+// iOS has no UWB_RANGING permission (Nearby Interaction is gated by NSNearbyInteractionUsageDescription),
+// so there is nothing to request here.
+actual suspend fun ensureUwbRangingPermission(): Boolean = true

--- a/uwbmodule/src/androidMain/kotlin/BleManager.kt
+++ b/uwbmodule/src/androidMain/kotlin/BleManager.kt
@@ -97,25 +97,7 @@ actual class BleManager(
                 Log.e(TAG, "local config not created")
                 return
             }
-            // The phone runs a controlee session (see MultiplatformUwbManager.controleeSessionScope),
-            // so in FiRa terms the accessory is the controller and OWNS the session parameters
-            // (sessionId + static-STS key + channel + preamble). A controlee must adopt them rather
-            // than impose its own, so we deliver the accessory's parsed config unchanged and range on
-            // it; the phone only contributes its own device address (sent to the accessory via the
-            // configure-and-start message in MultiplatformUwbManager.startRanging).
-            //
-            // NOTE: this reverses the previous behaviour, which overwrote the accessory's sessionId
-            // (and substituted the phone's key) with the phone's local values. If the accessory
-            // firmware instead expects the phone to dictate sessionId/key, that authority is wrong and
-            // we'd want the opposite. Flagged for hardware validation.
-            Log.d(
-                TAG,
-                "accessory config adopted: session=${remoteConfig.sessionId.toHexString()} " +
-                    "ch=${remoteConfig.channel} preamble=${remoteConfig.preambleIndex} " +
-                    "key=${remoteConfig.sessionKey?.toHexString()} " +
-                    "accessoryAddr=${remoteConfig.uwbAddress.toHexString()} " +
-                    "localAddr=${localConfig!!.uwbAddress.toHexString()}"
-            )
+
             configExchangedCallback?.invoke(peerId, remoteConfig) // this starts ranging
         } else {
             Log.e(TAG, "failed to parse config from $peerId")

--- a/uwbmodule/src/androidMain/kotlin/MultiplatformUwbManager.android.kt
+++ b/uwbmodule/src/androidMain/kotlin/MultiplatformUwbManager.android.kt
@@ -39,9 +39,9 @@ actual class MultiplatformUwbManager(private val androidUwbManager: UwbManager? 
     /** Active ranging coroutine jobs, keyed by peer ID. Cancel to stop ranging. */
     private val activeJobs = mutableMapOf<String, Job>()
 
+
     private val activeSessions = mutableMapOf<String, UwbSessionConfig>()
 
-    //private var controllerScope : UwbControllerSessionScope? = null
     /**
      * Our 8-byte static-STS session key, generated once and reused for the lifetime
      * of this manager so the value advertised over BLE matches the one used at ranging.
@@ -61,6 +61,7 @@ actual class MultiplatformUwbManager(private val androidUwbManager: UwbManager? 
             return
         }
         try {
+
             //val scope = androidUwbManager.controllerSessionScope()// androidUwbManager.controleeSessionScope()
             //sessionScope = scope
             // need this for ranging wit accessory, can't create later
@@ -88,6 +89,7 @@ actual class MultiplatformUwbManager(private val androidUwbManager: UwbManager? 
         // Generate a session ID from our address for deterministic agreement.
         // During config exchange, the initiator's sessionId is used by convention
         // (the peer with the lexicographically smaller address initiates).
+
         val sessionId:Int? = localAddress?.fold(0) { acc, b -> acc * 31 + (b.toInt() and 0xFF) }
 
         // Generate the static-STS key lazily and cache it, so the key we send over
@@ -137,7 +139,7 @@ actual class MultiplatformUwbManager(private val androidUwbManager: UwbManager? 
                     "ch=${remoteConfigAdjusted.channel} preamble=${remoteConfigAdjusted.preambleIndex} " +
                     "key=${remoteConfigAdjusted.sessionKey?.toHexString()} " +
                     "accessoryAddr=${remoteConfigAdjusted.uwbAddress.toHexString()} " +
-                    "localAddr=${sessionConfig!!.uwbAddress.toHexString()}"
+                    "localAddr=${sessionConfig.uwbAddress.toHexString()}"
         )
         // Cancel any existing ranging job for this peer
         activeJobs[peerId]?.cancel()
@@ -179,7 +181,7 @@ actual class MultiplatformUwbManager(private val androidUwbManager: UwbManager? 
                 val peerDevice = UwbDevice(peerAddress)
                 Log.d(TAG, "ranging peer device address is ${agreed.uwbAddress.toHexString()}")
 
-                val rangingParameters: RangingParameters? = RangingParameters(
+                val rangingParameters: RangingParameters = RangingParameters(
                     uwbConfigType = RangingParameters.CONFIG_UNICAST_DS_TWR,
                     sessionId = agreed.sessionId,
                     subSessionId = 0,
@@ -206,7 +208,8 @@ actual class MultiplatformUwbManager(private val androidUwbManager: UwbManager? 
                 }
 
 
-                rangingParameters?.let { ((activeSessions[peerId] as UwbSessionConfig).scope as UwbClientSessionScope).prepareSession(it) }
+
+                rangingParameters.let { ((activeSessions[peerId] as UwbSessionConfig).scope as UwbClientSessionScope).prepareSession(it) }
                     ?.catch { exception ->
                         errorCallback?.invoke("Ranging failed for $peerId: ${exception.message}")
                     }
@@ -294,3 +297,4 @@ actual class MultiplatformUwbManager(private val androidUwbManager: UwbManager? 
         coroutineScope.cancel()
         }
     }
+

--- a/uwbmodule/src/androidMain/kotlin/MultiplatformUwbManager.android.kt
+++ b/uwbmodule/src/androidMain/kotlin/MultiplatformUwbManager.android.kt
@@ -6,6 +6,7 @@ import androidx.core.uwb.RangingResult
 import androidx.core.uwb.UwbAddress
 import androidx.core.uwb.UwbClientSessionScope
 import androidx.core.uwb.UwbComplexChannel
+import androidx.core.uwb.UwbControllerSessionScope
 import androidx.core.uwb.UwbDevice
 import androidx.core.uwb.UwbManager
 import kotlinx.coroutines.CoroutineScope
@@ -37,6 +38,7 @@ actual class MultiplatformUwbManager(private val androidUwbManager: UwbManager? 
     /** Active ranging coroutine jobs, keyed by peer ID. Cancel to stop ranging. */
     private val activeJobs = mutableMapOf<String, Job>()
 
+    private var controllerScope : UwbControllerSessionScope? = null
     /**
      * Our 8-byte static-STS session key, generated once and reused for the lifetime
      * of this manager so the value advertised over BLE matches the one used at ranging.
@@ -56,8 +58,10 @@ actual class MultiplatformUwbManager(private val androidUwbManager: UwbManager? 
             return
         }
         try {
-            val scope = androidUwbManager.controleeSessionScope()
+            val scope = androidUwbManager.controllerSessionScope()// androidUwbManager.controleeSessionScope()
             sessionScope = scope
+            // need this for ranging wit accessory, can't create later
+            controllerScope = androidUwbManager.controllerSessionScope()
 
             val capabilities = scope.rangingCapabilities
             if (!capabilities.isDistanceSupported) {
@@ -69,14 +73,19 @@ actual class MultiplatformUwbManager(private val androidUwbManager: UwbManager? 
         }
     }
 
-    actual fun getLocalConfig(): UwbSessionConfig? {
-        val scope = sessionScope ?: return null
-        val localAddress = scope.localAddress.address
+    actual fun getLocalConfig(isAccessory: Boolean ): UwbSessionConfig? {
+        val scope = if(isAccessory) {
+            controllerScope
+        } else
+        {
+            sessionScope
+        }
+        val localAddress = scope?.localAddress?.address
 
         // Generate a session ID from our address for deterministic agreement.
         // During config exchange, the initiator's sessionId is used by convention
         // (the peer with the lexicographically smaller address initiates).
-        val sessionId = localAddress.fold(0) { acc, b -> acc * 31 + (b.toInt() and 0xFF) }
+        val sessionId = localAddress?.fold(0) { acc, b -> acc * 31 + (b.toInt() and 0xFF) }
 
         // Generate the static-STS key lazily and cache it, so the key we send over
         // BLE is the same one we compare/use when ranging starts.
@@ -84,34 +93,51 @@ actual class MultiplatformUwbManager(private val androidUwbManager: UwbManager? 
             .also { SecureRandom().nextBytes(it) }
             .also { localSessionKey = it }
 
-        Log.d(TAG, "phone address is ${localAddress.toHexString()}")
+        Log.d(TAG, "phone address is ${localAddress?.toHexString()}")
 
         return UwbSessionConfig(
             sessionId = sessionId,
             channel = DEFAULT_CHANNEL,
             preambleIndex = DEFAULT_PREAMBLE_INDEX,
-            uwbAddress = localAddress,
+            uwbAddress = localAddress!!,
             discoveryToken = null,
             sessionKey = key,
         )
     }
 
     actual fun startRanging(peerId: String, remoteConfig: UwbSessionConfig) {
-        val scope = sessionScope
+        val scope = if(remoteConfig.isAccessoryDevice){
+            controllerScope
+        }else {
+            sessionScope
+        }
         if (scope == null) {
             errorCallback?.invoke("UWB not initialized. Call initialize() first.")
             return
         }
-
+        val localConfig = getLocalConfig(remoteConfig.isAccessoryDevice)
+        // The phone runs a controller session (see MultiplatformUwbManager.controlerSessionScope),
+        // so in FiRa terms the phone is the controller and OWNS the session parameters
+        // (sessionId + static-STS key + channel + preamble).
+        val remoteConfigAdjusted = if(remoteConfig.isAccessoryDevice){
+            remoteConfig.copy(sessionId= localConfig!!.sessionId, sessionKey= localConfig.sessionKey)
+        } else {
+            remoteConfig
+        }
+        Log.d(
+            TAG,
+            "accessory config merged: session=${remoteConfigAdjusted.sessionId?.toHexString()} " +
+                    "ch=${remoteConfigAdjusted.channel} preamble=${remoteConfigAdjusted.preambleIndex} " +
+                    "key=${remoteConfigAdjusted.sessionKey?.toHexString()} " +
+                    "accessoryAddr=${remoteConfigAdjusted.uwbAddress.toHexString()} " +
+                    "localAddr=${localConfig!!.uwbAddress.toHexString()}"
+        )
         // Cancel any existing ranging job for this peer
         activeJobs[peerId]?.cancel()
 
         val job = coroutineScope.launch {
             try {
                 // Use the remote peer's UWB address
-                //val peerAddress = UwbAddress(remoteConfig.uwbAddress)
-                //val peerDevice = UwbDevice(peerAddress)
-                //Log.d(TAG, "device address is ${remoteConfig.uwbAddress.toHexString()}")
 
                 // Deterministic agreement without a handshake: the peer with the
                 // lexicographically smaller UWB address is the initiator, and both
@@ -120,18 +146,17 @@ actual class MultiplatformUwbManager(private val androidUwbManager: UwbManager? 
                 // exchange, so they independently compute the same values.
 
                 // unless it's an accessory device, in which case we should always use the remoteConfig
-                val localConfig = getLocalConfig()
-                Log.d(TAG,"accessory=${remoteConfig.isAccessoryDevice}")
-                var agreed = if (localConfig != null && !remoteConfig.isAccessoryDevice &&
-                    compareAddresses(localConfig.uwbAddress, remoteConfig.uwbAddress) <= 0
+                //val localConfig = getLocalConfig()
+                Log.d(TAG,"accessory=${remoteConfigAdjusted.isAccessoryDevice}")
+                val agreed = if (!remoteConfigAdjusted.isAccessoryDevice && compareAddresses(localConfig.uwbAddress, remoteConfigAdjusted.uwbAddress) <= 0
                 ) {
                     localConfig
                 } else {
-                    remoteConfig
+                    remoteConfigAdjusted
                 }
-
-                // don't use a local variable
-                if (agreed.sessionKey == null || agreed.sessionKey!!.size != SESSION_KEY_SIZE) {
+                Log.d(TAG, "sessionKey for agreed is ${agreed.sessionKey?.toHexString()}")
+                // if the remote's sessionKey is not set, oops, bail out
+                if ((agreed.sessionKey == null) || (agreed.sessionKey.size != SESSION_KEY_SIZE)) {
                     errorCallback?.invoke(
                         "Cannot range with $peerId: missing or invalid session key " +
                                 "(static STS requires $SESSION_KEY_SIZE bytes)"
@@ -146,37 +171,40 @@ actual class MultiplatformUwbManager(private val androidUwbManager: UwbManager? 
                 val peerDevice = UwbDevice(peerAddress)
                 Log.d(TAG, "ranging peer device address is ${agreed.uwbAddress.toHexString()}")
 
-                val rangingParameters = RangingParameters(
-                    uwbConfigType = RangingParameters.CONFIG_UNICAST_DS_TWR,
-                    sessionId = agreed.sessionId,
-                    subSessionId = 0,
-                    sessionKeyInfo = agreed.sessionKey,
-                    subSessionKeyInfo = null,
-                    complexChannel = UwbComplexChannel(
-                        channel = agreed.channel,
-                        preambleIndex = agreed.preambleIndex
-                    ),
-                    peerDevices = listOf(peerDevice),
-                    updateRateType = RangingParameters.RANGING_UPDATE_RATE_AUTOMATIC
-                )
+                val rangingParameters: RangingParameters? = agreed.sessionId?.let {
+                    RangingParameters(
+                        uwbConfigType = RangingParameters.CONFIG_UNICAST_DS_TWR,
+                        sessionId = it,
+                        subSessionId = 0,
+                        sessionKeyInfo = agreed.sessionKey,
+                        subSessionKeyInfo = null,
+                        complexChannel = UwbComplexChannel(
+                            channel = agreed.channel,
+                            preambleIndex = agreed.preambleIndex
+                        ),
+                        peerDevices = listOf(peerDevice),
+                        updateRateType = RangingParameters.RANGING_UPDATE_RATE_AUTOMATIC
+                    )
+                }
 
                 Log.d(
                     TAG,
-                    "Starting ranging with $peerId — session=${agreed.sessionId.toHexString()} ch=${agreed.channel} address=${agreed.uwbAddress.toHexString()}"
+                    "Starting ranging with $peerId — session=${agreed.sessionId?.toHexString()} ch=${agreed.channel} pai=${agreed.preambleIndex}  address=${agreed.uwbAddress.toHexString()}"
                 )
 
                 // if this is an accessory, send the config it should use now, as we have done all the pre-checking
                 if(agreed.isAccessoryDevice) {
-                    val message = byteArrayOf(ANDROID_ACCESSORY_CONFIGURE_AND_START)+ localConfig?.toByteArray()!!
+                    val message = byteArrayOf(ANDROID_ACCESSORY_CONFIGURE_AND_START)+ localConfig.toByteArray()
                     Log.d(TAG, "sending config data message to accessory=${message.toHexString()}")
                     localConfig.toByteArray().let { sendToPeerCallback?.invoke(peerId, message) }
                 }
 
-                scope.prepareSession(rangingParameters)
-                    .catch { exception ->
+
+                rangingParameters?.let { scope.prepareSession(it) }
+                    ?.catch { exception ->
                         errorCallback?.invoke("Ranging failed for $peerId: ${exception.message}")
                     }
-                    .collect { result ->
+                    ?.collect { result ->
                         Log.d(TAG, "in collect")
                         when (result) {
                             is RangingResult.RangingResultPosition -> {
@@ -191,66 +219,69 @@ actual class MultiplatformUwbManager(private val androidUwbManager: UwbManager? 
                                     )
                                 }
                             }
+
                             is RangingResult.RangingResultInitialized ->{
                                 Log.d(TAG,"Ranging init")
                             }
+
                             is RangingResult.RangingResultPeerDisconnected -> {
                                 Log.d(TAG,"peer disconnected")
                                 errorCallback?.invoke("Peer $peerId disconnected")
                                 activeJobs.remove(peerId)
                             }
+
                             else ->{
                                 Log.d(TAG,"unexpected ranging result ${result}")
                             }
                         }
                     }
-            } catch (e: Exception) {
-                Log.d(TAG,"Ranging startup failed, ${e.message}")
-                errorCallback?.invoke("Failed to start ranging with $peerId: ${e.message}")
-            }
-            Log.d(TAG,"Ranging active (maybe)")
-        }
-        Log.d(TAG,"Ranging process starting for peer ${peerId}")
-        activeJobs[peerId] = job
-    }
+} catch (e: Exception) {
+Log.d(TAG,"Ranging startup failed, ${e.message}")
+errorCallback?.invoke("Failed to start ranging with $peerId: ${e.message}")
+}
+Log.d(TAG,"Ranging active (maybe)")
+}
+Log.d(TAG,"Ranging process starting for peer ${peerId}")
+activeJobs[peerId] = job
+}
 
-    actual fun stopRanging(peerId: String) {
-        activeJobs.remove(peerId)?.let { job ->
-            job.cancel()
-            Log.d(TAG, "Stopped ranging with $peerId")
-        }
-    }
+actual fun stopRanging(peerId: String) {
+activeJobs.remove(peerId)?.let { job ->
+job.cancel()
+Log.d(TAG, "Stopped ranging with $peerId")
+}
+}
 
-    actual fun setRangingCallback(callback: (peerId: String, distance: Double, azimuth: Double?, elevation: Double?) -> Unit) {
-        rangingCallback = callback
-    }
+actual fun setRangingCallback(callback: (peerId: String, distance: Double, azimuth: Double?, elevation: Double?) -> Unit) {
+rangingCallback = callback
+}
 
-    actual fun setSendToPeerCallback(callback: (peerId: String, data: ByteArray) -> Unit) {
-        sendToPeerCallback = callback
-    }
+actual fun setSendToPeerCallback(callback: (peerId: String, data: ByteArray) -> Unit) {
+sendToPeerCallback = callback
+}
 
-    actual fun setErrorCallback(callback: (error: String) -> Unit) {
-        errorCallback = callback
-    }
+actual fun setErrorCallback(callback: (error: String) -> Unit) {
+errorCallback = callback
+}
 
-    /**
-     * Compare two UWB addresses lexicographically (unsigned, byte by byte).
-     * Returns a negative value if [a] sorts before [b], positive if after, 0 if equal.
-     */
-    private fun compareAddresses(a: ByteArray, b: ByteArray): Int {
-        val len = minOf(a.size, b.size)
-        for (i in 0 until len) {
-            val diff = (a[i].toInt() and 0xFF) - (b[i].toInt() and 0xFF)
-            if (diff != 0) return diff
-        }
-        return a.size - b.size
-    }
+/**
+* Compare two UWB addresses lexicographically (unsigned, byte by byte).
+* Returns a negative value if [a] sorts before [b], positive if after, 0 if equal.
+*/
+private fun compareAddresses(a: ByteArray, b: ByteArray): Int {
+val len = minOf(a.size, b.size)
+for (i in 0 until len) {
+val diff = (a[i].toInt() and 0xFF) - (b[i].toInt() and 0xFF)
+if (diff != 0) return diff
+}
+return a.size - b.size
+}
 
-    /** Stop all sessions and clean up resources. */
-    actual fun cleanup() {
-        activeJobs.values.forEach { it.cancel() }
-        activeJobs.clear()
-        sessionScope = null
-        coroutineScope.cancel()
-    }
+/** Stop all sessions and clean up resources. */
+actual fun cleanup() {
+activeJobs.values.forEach { it.cancel() }
+activeJobs.clear()
+sessionScope = null
+coroutineScope.cancel()
+}
 }

--- a/uwbmodule/src/commonMain/kotlin/DeviceDiscoveryManager.kt
+++ b/uwbmodule/src/commonMain/kotlin/DeviceDiscoveryManager.kt
@@ -108,7 +108,7 @@ class DeviceDiscoveryManager(
     }
 
     /** Get the local UWB config (address, session ID, channel) for display. */
-    fun getLocalConfig(): UwbSessionConfig? = multiplatformUwbManager.getLocalConfig()
+    suspend fun getLocalConfig(): UwbSessionConfig? = multiplatformUwbManager.getLocalConfig(false)
 
     suspend fun startScanning() {
         if (isScanning) return
@@ -118,7 +118,7 @@ class DeviceDiscoveryManager(
         multiplatformUwbManager.initialize()
 
         // Start GATT server so peers can exchange configs with us
-        val localConfig = multiplatformUwbManager.getLocalConfig()
+        val localConfig = multiplatformUwbManager.getLocalConfig(false)
         if (localConfig != null) {
             bleManager.startGattServer(localConfig)
         }
@@ -136,7 +136,7 @@ class DeviceDiscoveryManager(
         }
     }
 
-    fun stopScanning() {
+    suspend fun stopScanning() {
         if (!isScanning) return
         isScanning = false
 
@@ -169,7 +169,7 @@ class DeviceDiscoveryManager(
      * Clean up all resources, including UWB manager and BLE manager.
      * Should be called when the manager is no longer needed (e.g., in ViewModel.onCleared).
      */
-    fun cleanup() {
+    suspend fun cleanup() {
         stopScanning()
         multiplatformUwbManager.cleanup()
         bleManager.cleanup()
@@ -218,7 +218,7 @@ class DeviceDiscoveryManager(
 
         // Initiate config exchange if not already done/pending
         if (id !in exchangedPeers && id !in pendingExchanges) {
-            val localConfig = multiplatformUwbManager.getLocalConfig()
+            val localConfig = multiplatformUwbManager.getLocalConfig(false)
             if (localConfig != null) {
                 pendingExchanges.add(id)
                 emitEvent(EventType.ConfigExchangeStarted, id, "Starting GATT config exchange")

--- a/uwbmodule/src/commonMain/kotlin/DeviceDiscoveryManager.kt
+++ b/uwbmodule/src/commonMain/kotlin/DeviceDiscoveryManager.kt
@@ -242,7 +242,7 @@ class DeviceDiscoveryManager(
 
             emitEvent(
                 EventType.ConfigExchangeComplete, peerId,
-                "Config exchanged — session=${remoteConfig.sessionId.toHexString()} ch=${remoteConfig.channel} addr=${remoteConfig.uwbAddress.toHexString()}"
+                "Config exchanged — session=${remoteConfig.sessionId?.toHexString()} ch=${remoteConfig.channel} addr=${remoteConfig.uwbAddress.toHexString()}"
             )
 
             // Ensure peer is in our device list and update with config info

--- a/uwbmodule/src/commonMain/kotlin/MultiplatformUwbManager.kt
+++ b/uwbmodule/src/commonMain/kotlin/MultiplatformUwbManager.kt
@@ -20,7 +20,7 @@ expect class MultiplatformUwbManager {
      * On Android: contains local UWB address, proposed session ID, channel, preamble.
      * On iOS: contains serialized NI discovery token.
      */
-    fun getLocalConfig(): UwbSessionConfig?
+    fun getLocalConfig(isAccessory:Boolean= false): UwbSessionConfig?
 
     /**
      * Start ranging with a peer using exchanged configurations.

--- a/uwbmodule/src/commonMain/kotlin/UwbSessionConfig.kt
+++ b/uwbmodule/src/commonMain/kotlin/UwbSessionConfig.kt
@@ -38,7 +38,7 @@ data class UwbSessionConfig(
     /**
      * Serialize to a simple binary format for BLE GATT exchange.
      *
-     * Format (big-endian):
+     * Format (little-endian):
      * ```
      * [1B version][4B sessionId][4B channel][4B preambleIndex]
      * [2B uwbAddr.size][uwbAddr bytes]
@@ -46,7 +46,11 @@ data class UwbSessionConfig(
      * [2B key.size][key bytes]       // optional trailer; absent or size=0 if null
      * [2B acc.size][acc bytes]       // optional trailer; absent or size=0 if null
      * ```
-     * The session-key and accessory-data trailers are optional so older payloads still parse.
+     * Multi-byte integers (sessionId, channel, preambleIndex, and the 2-byte length prefixes) are
+     * little-endian to match the FiRa/UWB convention, so accessory firmware can lay the struct out
+     * natively without byte-swapping. The byte-array fields (address, token, key) are opaque and are
+     * copied verbatim. The session-key and accessory-data trailers are optional so older/shorter
+     * payloads still parse.
      */
     fun toByteArray(): ByteArray {
         val tokenBytes = discoveryToken ?: ByteArray(0)
@@ -59,45 +63,45 @@ data class UwbSessionConfig(
         // Version
         buf[pos++] = PROTOCOL_VERSION
 
-        // sessionId
-        buf[pos++] = (sessionId shr 24).toByte()
-        buf[pos++] = (sessionId shr 16).toByte()
-        buf[pos++] = (sessionId shr 8).toByte()
+        // sessionId (LE)
         buf[pos++] = sessionId.toByte()
+        buf[pos++] = (sessionId shr 8).toByte()
+        buf[pos++] = (sessionId shr 16).toByte()
+        buf[pos++] = (sessionId shr 24).toByte()
 
-        // channel
-        buf[pos++] = (channel shr 24).toByte()
-        buf[pos++] = (channel shr 16).toByte()
-        buf[pos++] = (channel shr 8).toByte()
+        // channel (LE)
         buf[pos++] = channel.toByte()
+        buf[pos++] = (channel shr 8).toByte()
+        buf[pos++] = (channel shr 16).toByte()
+        buf[pos++] = (channel shr 24).toByte()
 
-        // preambleIndex
-        buf[pos++] = (preambleIndex shr 24).toByte()
-        buf[pos++] = (preambleIndex shr 16).toByte()
-        buf[pos++] = (preambleIndex shr 8).toByte()
+        // preambleIndex (LE)
         buf[pos++] = preambleIndex.toByte()
+        buf[pos++] = (preambleIndex shr 8).toByte()
+        buf[pos++] = (preambleIndex shr 16).toByte()
+        buf[pos++] = (preambleIndex shr 24).toByte()
 
         // uwbAddress
-        buf[pos++] = (uwbAddress.size shr 8).toByte()
         buf[pos++] = uwbAddress.size.toByte()
+        buf[pos++] = (uwbAddress.size shr 8).toByte()
         uwbAddress.copyInto(buf, pos)
         pos += uwbAddress.size
 
         // discoveryToken
-        buf[pos++] = (tokenBytes.size shr 8).toByte()
         buf[pos++] = tokenBytes.size.toByte()
+        buf[pos++] = (tokenBytes.size shr 8).toByte()
         tokenBytes.copyInto(buf, pos)
         pos += tokenBytes.size
 
         // sessionKey
-        buf[pos++] = (keyBytes.size shr 8).toByte()
         buf[pos++] = keyBytes.size.toByte()
+        buf[pos++] = (keyBytes.size shr 8).toByte()
         keyBytes.copyInto(buf, pos)
         pos += keyBytes.size
 
         // accessoryData
-        buf[pos++] = (accBytes.size shr 8).toByte()
         buf[pos++] = accBytes.size.toByte()
+        buf[pos++] = (accBytes.size shr 8).toByte()
         accBytes.copyInto(buf, pos)
 
         return buf
@@ -185,14 +189,15 @@ data class UwbSessionConfig(
             )
         }
 
+        // Little-endian readers (least-significant byte first), matching toByteArray.
         private fun readInt(bytes: ByteArray, offset: Int): Int =
-            ((bytes[offset].toInt() and 0xFF) shl 24) or
-                    ((bytes[offset + 1].toInt() and 0xFF) shl 16) or
-                    ((bytes[offset + 2].toInt() and 0xFF) shl 8) or
-                    (bytes[offset + 3].toInt() and 0xFF)
+            (bytes[offset].toInt() and 0xFF) or
+                    ((bytes[offset + 1].toInt() and 0xFF) shl 8) or
+                    ((bytes[offset + 2].toInt() and 0xFF) shl 16) or
+                    ((bytes[offset + 3].toInt() and 0xFF) shl 24)
 
         private fun readShort(bytes: ByteArray, offset: Int): Int =
-            ((bytes[offset].toInt() and 0xFF) shl 8) or
-                    (bytes[offset + 1].toInt() and 0xFF)
+            (bytes[offset].toInt() and 0xFF) or
+                    ((bytes[offset + 1].toInt() and 0xFF) shl 8)
     }
 }

--- a/uwbmodule/src/commonMain/kotlin/UwbSessionConfig.kt
+++ b/uwbmodule/src/commonMain/kotlin/UwbSessionConfig.kt
@@ -8,7 +8,7 @@ package com.dustedrob.uwb
  */
 data class UwbSessionConfig(
     /** Agreed-upon session identifier. Both peers must use the same value. */
-    var sessionId: Int,
+    val sessionId: Int?,
     /** UWB channel number (e.g., 9). */
     val channel: Int,
     /** Preamble index for the UWB channel (e.g., 10). */
@@ -23,7 +23,7 @@ data class UwbSessionConfig(
      * Required by androidx.core.uwb for `CONFIG_UNICAST_DS_TWR`; both peers must
      * use the same key. Exchanged here so the two ends can agree on one.
      */
-    var sessionKey: ByteArray? = null,
+    val sessionKey: ByteArray? = null,
     /**
      * Opaque Apple/Qorvo Nearby-Interaction **Accessory Configuration Data** (iOS accessory) or null.
      *
@@ -60,10 +60,10 @@ data class UwbSessionConfig(
         buf[pos++] = PROTOCOL_VERSION
 
         // sessionId
-        buf[pos++] = (sessionId shr 24).toByte()
-        buf[pos++] = (sessionId shr 16).toByte()
-        buf[pos++] = (sessionId shr 8).toByte()
-        buf[pos++] = sessionId.toByte()
+        buf[pos++] = (sessionId?.shr(24))?.toByte() ?: 0
+        buf[pos++] = (sessionId?.shr(16))?.toByte() ?: 0
+        buf[pos++] = (sessionId?.shr(8))?.toByte() ?: 0
+        buf[pos++] = sessionId?.toByte() ?: 0
 
         // channel
         buf[pos++] = (channel shr 24).toByte()
@@ -122,13 +122,13 @@ data class UwbSessionConfig(
     }
 
     override fun hashCode(): Int {
-        var result = sessionId
-        result = 31 * result + channel
-        result = 31 * result + preambleIndex
-        result = 31 * result + uwbAddress.contentHashCode()
-        result = 31 * result + (discoveryToken?.contentHashCode() ?: 0)
-        result = 31 * result + (sessionKey?.contentHashCode() ?: 0)
-        result = 31 * result + (accessoryData?.contentHashCode() ?: 0)
+        var result :Int = sessionId!!
+        result =  31 * result + channel
+        result =  31 * result + preambleIndex
+        result =  31 * result + uwbAddress.contentHashCode()
+        result =  31 * result + (discoveryToken?.contentHashCode() ?: 0)
+        result =  31 * result + (sessionKey?.contentHashCode() ?: 0)
+        result =  31 * result + (accessoryData?.contentHashCode() ?: 0)
         return result
     }
 

--- a/uwbmodule/src/commonTest/kotlin/com/dustedrob/uwb/UwbSessionConfigTest.kt
+++ b/uwbmodule/src/commonTest/kotlin/com/dustedrob/uwb/UwbSessionConfigTest.kt
@@ -139,26 +139,55 @@ class UwbSessionConfigTest {
     }
 
     @Test
-    fun parsesLegacyPayloadWithoutKeyTrailer() {
-        // A payload from before the session-key trailer existed: it ends right after
-        // the discovery-token block, with no [2B key.size] trailer at all.
+    fun parsesShortPayloadWithoutKeyTrailer() {
+        // A minimal payload that ends right after the discovery-token block, with no [2B key.size]
+        // trailer at all. Bytes are little-endian (LSB first), matching the wire format.
         val sid = 42
         val ch = 9
         val pre = 10
         val addr = byteArrayOf(0x01, 0x02)
-        val legacy = byteArrayOf(
+        val short = byteArrayOf(
             1, // version
-            (sid shr 24).toByte(), (sid shr 16).toByte(), (sid shr 8).toByte(), sid.toByte(),
-            (ch shr 24).toByte(), (ch shr 16).toByte(), (ch shr 8).toByte(), ch.toByte(),
-            (pre shr 24).toByte(), (pre shr 16).toByte(), (pre shr 8).toByte(), pre.toByte(),
-            (addr.size shr 8).toByte(), addr.size.toByte(), addr[0], addr[1],
+            sid.toByte(), (sid shr 8).toByte(), (sid shr 16).toByte(), (sid shr 24).toByte(),
+            ch.toByte(), (ch shr 8).toByte(), (ch shr 16).toByte(), (ch shr 24).toByte(),
+            pre.toByte(), (pre shr 8).toByte(), (pre shr 16).toByte(), (pre shr 24).toByte(),
+            addr.size.toByte(), (addr.size shr 8).toByte(), addr[0], addr[1],
             0, 0, // token size = 0
         )
-        val restored = UwbSessionConfig.fromByteArray(legacy)
+        val restored = UwbSessionConfig.fromByteArray(short)
         assertNotNull(restored)
         assertEquals(sid, restored.sessionId)
         assertNull(restored.sessionKey)
         assertNull(restored.accessoryData)
+    }
+
+    @Test
+    fun serializesMultiByteFieldsLittleEndian() {
+        // Pins the wire contract: multi-byte integers are little-endian (LSB first) so accessory
+        // firmware can lay out its FiRa struct natively (session_id = 0x691A4B22, channel = 9,
+        // preamble = 10, address_size = 2) without byte-swapping.
+        val config = UwbSessionConfig(
+            sessionId = 0x691A4B22,
+            channel = 9,
+            preambleIndex = 10,
+            uwbAddress = byteArrayOf(0x02, 0xC9.toByte()),
+        )
+        val b = config.toByteArray()
+        assertEquals(1.toByte(), b[0]) // version
+        // sessionId 0x691A4B22 -> 22 4B 1A 69
+        assertEquals(0x22.toByte(), b[1]); assertEquals(0x4B.toByte(), b[2])
+        assertEquals(0x1A.toByte(), b[3]); assertEquals(0x69.toByte(), b[4])
+        // channel 9 -> 09 00 00 00
+        assertEquals(0x09.toByte(), b[5]); assertEquals(0.toByte(), b[6])
+        assertEquals(0.toByte(), b[7]); assertEquals(0.toByte(), b[8])
+        // preambleIndex 10 -> 0A 00 00 00
+        assertEquals(0x0A.toByte(), b[9]); assertEquals(0.toByte(), b[10])
+        assertEquals(0.toByte(), b[11]); assertEquals(0.toByte(), b[12])
+        // address size 2 -> 02 00, then the 2 address bytes verbatim
+        assertEquals(0x02.toByte(), b[13]); assertEquals(0.toByte(), b[14])
+        assertEquals(0x02.toByte(), b[15]); assertEquals(0xC9.toByte(), b[16])
+        // and it round-trips
+        assertEquals(config, UwbSessionConfig.fromByteArray(b))
     }
 
     @Test

--- a/uwbmodule/src/iosMain/kotlin/BleManager.kt
+++ b/uwbmodule/src/iosMain/kotlin/BleManager.kt
@@ -60,7 +60,7 @@ actual class BleManager(
     /** Deliver an accessory's raw configuration blob (opaque — wrapped, not parsed as our envelope). */
     private fun deliverAccessoryConfig(peerId: String, raw: ByteArray) {
         NSLog("BleManager: received accessory config from $peerId (${raw.size} bytes)")
-        configExchangedCallback?.invoke(peerId, UwbSessionConfig(0, 0, 0, ByteArray(0), accessoryData = raw))
+        configExchangedCallback?.invoke(peerId, UwbSessionConfig(0, 0, 0, 0,ByteArray(0), accessoryData = raw))
     }
 
     /** Find a characteristic on a discovered service by UUID string (CBUUID normalizes short/long). */

--- a/uwbmodule/src/iosMain/kotlin/MultiplatformUwbManager.ios.kt
+++ b/uwbmodule/src/iosMain/kotlin/MultiplatformUwbManager.ios.kt
@@ -79,7 +79,7 @@ actual class MultiplatformUwbManager {
         }
     }
 
-    actual fun getLocalConfig(): UwbSessionConfig? {
+    actual fun getLocalConfig(isAccessory:Boolean): UwbSessionConfig? {
         val token = localDiscoveryToken ?: return null
 
         // Serialize the discovery token via NSKeyedArchiver

--- a/uwbmodule/src/iosMain/kotlin/MultiplatformUwbManager.ios.kt
+++ b/uwbmodule/src/iosMain/kotlin/MultiplatformUwbManager.ios.kt
@@ -80,6 +80,7 @@ actual class MultiplatformUwbManager {
     }
 
     actual suspend fun getLocalConfig(isAccessory:Boolean): UwbSessionConfig? {
+
         val token = localDiscoveryToken ?: return null
 
         // Serialize the discovery token via NSKeyedArchiver

--- a/uwbmodule/src/iosMain/kotlin/MultiplatformUwbManager.ios.kt
+++ b/uwbmodule/src/iosMain/kotlin/MultiplatformUwbManager.ios.kt
@@ -79,7 +79,7 @@ actual class MultiplatformUwbManager {
         }
     }
 
-    actual fun getLocalConfig(isAccessory:Boolean): UwbSessionConfig? {
+    actual suspend fun getLocalConfig(isAccessory:Boolean): UwbSessionConfig? {
         val token = localDiscoveryToken ?: return null
 
         // Serialize the discovery token via NSKeyedArchiver
@@ -102,6 +102,7 @@ actual class MultiplatformUwbManager {
         val tokenBytes = tokenData.toByteArray()
 
         return UwbSessionConfig(
+            scope = 0,
             sessionId = 0, // Not used on iOS
             channel = 0,
             preambleIndex = 0,
@@ -110,7 +111,7 @@ actual class MultiplatformUwbManager {
         )
     }
 
-    actual fun startRanging(peerId: String, remoteConfig: UwbSessionConfig) {
+    actual suspend fun startRanging(peerId: String, remoteConfig: UwbSessionConfig) {
         val session = niSession
         if (session == null) {
             errorCallback?.invoke("NI session not initialized. Call initialize() first.")
@@ -177,7 +178,7 @@ actual class MultiplatformUwbManager {
         session.runWithConfiguration(config)
     }
 
-    actual fun stopRanging(peerId: String) {
+    actual suspend fun stopRanging(peerId: String) {
         activePeers.remove(peerId)
         if (peerId == accessoryPeerId) accessoryPeerId = null
         if (activePeers.isEmpty() && accessoryPeerId == null) {
@@ -198,7 +199,7 @@ actual class MultiplatformUwbManager {
         errorCallback = callback
     }
 
-    actual fun cleanup() {
+    actual suspend fun cleanup() {
         niSession?.invalidate()
         niSession = null
         activePeers.clear()

--- a/uwbmodule/src/iosMain/kotlin/MultiplatformUwbManager.ios.kt
+++ b/uwbmodule/src/iosMain/kotlin/MultiplatformUwbManager.ios.kt
@@ -22,13 +22,14 @@ import platform.NearbyInteraction.NINearbyObjectRemovalReason
 import platform.NearbyInteraction.NINearbyPeerConfiguration
 import platform.NearbyInteraction.NISession
 import platform.NearbyInteraction.NISessionDelegateProtocol
+import platform.Security.kSSLSessionConfig_ATSv1
 import platform.darwin.NSObject
 import platform.darwin.dispatch_async
 import platform.darwin.dispatch_get_main_queue
 
 @OptIn(ExperimentalForeignApi::class)
 actual class MultiplatformUwbManager {
-    private var niSession: NISession? = null
+    //private var niSession: NISession? = null
     private var rangingCallback: ((String, Double, Double?, Double?) -> Unit)? = null
     private var errorCallback: ((String) -> Unit)? = null
 
@@ -36,7 +37,7 @@ actual class MultiplatformUwbManager {
     private var sendToPeerCallback: ((String, ByteArray) -> Unit)? = null
 
     /** The accessory peer currently being ranged (single-accessory session; multi-accessory is future). */
-    private var accessoryPeerId: String? = null
+    //private var accessoryPeerId: String? = null
 
     /**
      * NearbyInteraction direction APIs (`horizontalAngle`, `verticalDirectionEstimate`) are iOS 16+.
@@ -48,11 +49,13 @@ actual class MultiplatformUwbManager {
     /** Maps peer ID → the token we received from that peer. */
     private val activePeers = mutableMapOf<String, NIDiscoveryToken>()
 
+    private val activeSessions = mutableMapOf<String, UwbSessionConfig>()
+
     /** Our local discovery token, available after session creation. */
-    private var localDiscoveryToken: NIDiscoveryToken? = null
+    //private var localDiscoveryToken: NIDiscoveryToken? = null
 
     /** Strong reference to delegate to prevent GC. */
-    private var sessionDelegate: SessionDelegate? = null
+    //private var sessionDelegate: SessionDelegate? = null
 
     /*actual suspend fun initialize(){
 
@@ -62,24 +65,22 @@ actual class MultiplatformUwbManager {
             errorCallback?.invoke("NearbyInteraction not supported on this device")
             return
         }
+    }
 
-        val session = NISession()
-        niSession = session
+    actual suspend fun getLocalConfig(isAccessory:Boolean): UwbSessionConfig? {
 
+        val session = NISession();
         val delegate = SessionDelegate()
-        sessionDelegate = delegate
+
         session.delegate = delegate
 
         // The session's discoveryToken is available immediately after creation
-        localDiscoveryToken = session.discoveryToken
+        val localDiscoveryToken = session.discoveryToken
         if (localDiscoveryToken == null) {
             NSLog("UwbManager: Warning — discoveryToken is null after session creation")
         } else {
             NSLog("UwbManager: Initialized with discovery token")
         }
-    }
-
-    actual suspend fun getLocalConfig(isAccessory:Boolean): UwbSessionConfig? {
 
         val token = localDiscoveryToken ?: return null
 
@@ -103,7 +104,7 @@ actual class MultiplatformUwbManager {
         val tokenBytes = tokenData.toByteArray()
 
         return UwbSessionConfig(
-            scope = 0,
+            scope = session,
             sessionId = 0, // Not used on iOS
             channel = 0,
             preambleIndex = 0,
@@ -113,12 +114,8 @@ actual class MultiplatformUwbManager {
     }
 
     actual suspend fun startRanging(peerId: String, remoteConfig: UwbSessionConfig) {
-        val session = niSession
-        if (session == null) {
-            errorCallback?.invoke("NI session not initialized. Call initialize() first.")
-            return
-        }
 
+        val sessionConfig = getLocalConfig(remoteConfig.isAccessoryDevice)
         // Accessory ranging: build an accessory configuration from the accessory's data blob. NI then
         // generates shareable configuration data (see didGenerateShareableConfigurationData), which we
         // write back to the accessory over BLE to actually start ranging.
@@ -140,9 +137,10 @@ actual class MultiplatformUwbManager {
                     NSLog("MultiPlatformMgr device DOES NOT support camera assistance")
                 }
             }
-            accessoryPeerId = peerId
+            activeSessions[peerId]= sessionConfig as UwbSessionConfig
+            //accessoryPeerId = peerId
             NSLog("UwbManager: Starting accessory ranging with $peerId")
-            session.runWithConfiguration(config)
+            (sessionConfig.scope as NISession).runWithConfiguration(config)
             return
         }
 
@@ -171,19 +169,19 @@ actual class MultiplatformUwbManager {
         }
 
         activePeers[peerId] = peerToken
-
+        activeSessions[peerId] = sessionConfig as UwbSessionConfig
         // Create a peer configuration with the exchanged token
         val config = NINearbyPeerConfiguration(peerToken)
 
         NSLog("UwbManager: Starting ranging with $peerId")
-        session.runWithConfiguration(config)
+        (sessionConfig.scope as NISession).runWithConfiguration(config)
     }
 
     actual suspend fun stopRanging(peerId: String) {
         activePeers.remove(peerId)
-        if (peerId == accessoryPeerId) accessoryPeerId = null
-        if (activePeers.isEmpty() && accessoryPeerId == null) {
-            niSession?.pause()
+        if (activePeers.isEmpty()) {
+            ((activeSessions[peerId]?.scope) as NISession).pause()
+            activeSessions.remove(peerId)
             NSLog("UwbManager: Paused session (no active peers)")
         }
     }
@@ -201,12 +199,8 @@ actual class MultiplatformUwbManager {
     }
 
     actual suspend fun cleanup() {
-        niSession?.invalidate()
-        niSession = null
         activePeers.clear()
-        accessoryPeerId = null
-        localDiscoveryToken = null
-        sessionDelegate = null
+        activeSessions.clear()
         NSLog("UwbManager: Cleanup completed")
     }
 
@@ -222,9 +216,8 @@ actual class MultiplatformUwbManager {
                         if (!distance.isNaN()) {
                             // Accessory objects aren't in activePeers (keyed by peer tokens), so fall
                             // back to the tracked accessory peer.
-                            val peerId = activePeers.entries
-                                .find { it.value == obj.discoveryToken }?.key
-                                ?: accessoryPeerId ?: "unknown"
+                            val peerId:String = activeSessions.entries
+                                .firstOrNull { it.value.scope  == session }?.key ?: "unknown"
 
                             // Azimuth (`horizontalAngle`) is iOS 16+ and is NaN until camera-assistance
                             // convergence, so only emit it when available and valid. NearbyInteraction
@@ -257,9 +250,9 @@ actual class MultiplatformUwbManager {
             dispatchToMain {
                 didRemoveNearbyObjects.forEach { obj ->
                     if (obj is NINearbyObject) {
-                        val peerId = activePeers.entries
-                            .find { it.value == obj.discoveryToken }?.key
-                        peerId?.let {
+                        val peerId:String = activeSessions.entries
+                            .firstOrNull { it.value.scope  == session }?.key ?: "unknown"
+                        peerId.let {
                             activePeers.remove(it)
                             NSLog("UwbManager: Peer $it removed, reason=$withReason")
                         }
@@ -274,8 +267,7 @@ actual class MultiplatformUwbManager {
                 NSLog("UwbManager: Session invalidated: $msg")
                 errorCallback?.invoke("NI Session error: $msg")
                 activePeers.clear()
-                niSession = null
-                localDiscoveryToken = null
+                activeSessions.clear()
             }
         }
 
@@ -286,11 +278,9 @@ actual class MultiplatformUwbManager {
         ) {
             // Accessory ranging: NI produced the data the accessory needs to start. Send it back over
             // BLE, prefixed with the configure-and-start message id.
-            val peerId = accessoryPeerId
-            if (peerId == null) {
-                NSLog("UwbManager: shareable config generated but no accessory peer tracked")
-                return
-            }
+            val peerId:String = activeSessions.entries
+                .firstOrNull { it.value.scope  == session }?.key ?: "unknown"
+
             val payload = byteArrayOf(NI_ACCESSORY_CONFIGURE_AND_START) + didGenerateShareableConfigurationData.toByteArray()
             NSLog("UwbManager: sending configure-and-start to $peerId (${payload.size} bytes)")
             sendToPeerCallback?.invoke(peerId, payload)
@@ -335,7 +325,9 @@ actual class MultiplatformUwbManager {
         }
 
         override fun sessionDidStartRunning(session: NISession) {
-            NSLog("UwbManager: Session started running")
+            val peerId:String = activeSessions.entries
+                .firstOrNull { it.value.scope  == session }?.key ?: "unknown"
+            NSLog("UwbManager: Session started running for ${peerId}")
         }
 
         override fun sessionWasSuspended(session: NISession) {

--- a/uwbmodule/src/iosMain/kotlin/MultiplatformUwbManager.ios.kt
+++ b/uwbmodule/src/iosMain/kotlin/MultiplatformUwbManager.ios.kt
@@ -51,11 +51,13 @@ actual class MultiplatformUwbManager {
 
     private val activeSessions = mutableMapOf<String, UwbSessionConfig>()
 
+    private val activeDelegates = mutableMapOf<NISession, SessionDelegate>()
+
     /** Our local discovery token, available after session creation. */
     //private var localDiscoveryToken: NIDiscoveryToken? = null
 
     /** Strong reference to delegate to prevent GC. */
-    //private var sessionDelegate: SessionDelegate? = null
+    private var sessionDelegate: SessionDelegate? = null
 
     /*actual suspend fun initialize(){
 
@@ -71,7 +73,7 @@ actual class MultiplatformUwbManager {
 
         val session = NISession();
         val delegate = SessionDelegate()
-
+        activeDelegates[session] = delegate
         session.delegate = delegate
 
         // The session's discoveryToken is available immediately after creation
@@ -181,6 +183,7 @@ actual class MultiplatformUwbManager {
         activePeers.remove(peerId)
         if (activePeers.isEmpty()) {
             ((activeSessions[peerId]?.scope) as NISession).pause()
+            activeDelegates.remove((activeSessions[peerId]?.scope) as NISession)
             activeSessions.remove(peerId)
             NSLog("UwbManager: Paused session (no active peers)")
         }
@@ -268,6 +271,7 @@ actual class MultiplatformUwbManager {
                 errorCallback?.invoke("NI Session error: $msg")
                 activePeers.clear()
                 activeSessions.clear()
+                activeDelegates.clear()
             }
         }
 
@@ -331,6 +335,9 @@ actual class MultiplatformUwbManager {
         }
 
         override fun sessionWasSuspended(session: NISession) {
+            val peerId:String = activeSessions.entries
+                .firstOrNull { it.value.scope  == session }?.key ?: "unknown"
+            NSLog("UwbManager: Session suspended for ${peerId}")
             dispatchToMain {
                 errorCallback?.invoke("NI Session was suspended")
             }


### PR DESCRIPTION
this implements multi session for accessories..

I added scope to the UWBSessionConfig  because it holds the HW address and that is sent to the remote..
the scope is not sent.. 

multi-session ranges with multiple successfully, with different angles between.. pretty cool, see below
reporting is wrong as discovery manager as the wrong remoteConfig in 
 internal suspend fun onConfigExchanged(
as we haven't selected or merged yet in PlatformManager..

it also doesn't range direct (android<->android and ios<->ios), due to all the problems discussed in #49 

this has the little endian pr applied  as the firmware now needs that

<img width="1440" height="3120" alt="1000000056" src="https://github.com/user-attachments/assets/85d59b5c-4173-42c0-8641-0f1e9f3ddef9" />
