### PR TITLE
Add opt-in flag for the accessory protocol; fix sessionId==0 parse regression

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,45 @@ Add required permissions to `Info.plist`:
 <string>This app uses Bluetooth to advertise UWB capabilities</string>
 ```
 
+### Accessory ranging (opt-in)
+
+Beyond phone-to-phone ranging, the library can range with a UWB **accessory** (a Qorvo/NXP
+board and similar). This is handled by profiles whose `exchange` is
+`ExchangeProtocol.AccessoryNotify`, and it is **off by default** because it requires **compatible
+accessory firmware** — the phone speaks a distinct, hardware-specific exchange to the device, not
+the standard peer-to-peer flow. Point a stock accessory at it and nothing will match.
+
+To enable it, add an accessory profile *and* set `enableAccessoryProtocol = true` on
+`BleDiscoveryConfig`:
+
+```kotlin
+managerFactory.createBleManager(
+    BleDiscoveryConfig(
+        profiles = listOf(LOCAL_PROFILE, QorvoNearbyProfile), // QorvoNearbyProfile is app-owned
+        enableAccessoryProtocol = true,                       // deliberate opt-in; default false
+    )
+)
+```
+
+When the flag is left `false`, any `AccessoryNotify` profiles are ignored for discovery and
+exchange (a warning is logged), so peer-to-peer ranging is unaffected. See
+`AccessoryProfiles.kt` and `UwbDiscoveryViewModel` in the sample app for a working setup.
+
+**How the exchange works (per accessory):**
+
+1. Phone scans, discovers the accessory by its advertised UUID, and connects.
+2. Phone writes an **init** command (`ANDROID_ACCESSORY_INIT_COMMAND`).
+3. Accessory notifies back a `UwbSessionConfig` (its UWB address, etc.).
+4. Phone acts as the FiRa **controller**: it assigns the session ID, static-STS key, channel, and
+   preamble, starts ranging, and writes a **configure-and-start** command
+   (`ANDROID_ACCESSORY_CONFIGURE_AND_START`) with that config back to the accessory.
+5. On stop, the phone sends a **stop** command and disconnects.
+
+The `UwbSessionConfig` wire format is little-endian to match the FiRa/UWB convention, so accessory
+firmware can lay its struct out natively. On iOS the equivalent path uses Apple's Nearby Interaction
+Accessory Protocol (`NINearbyAccessoryConfiguration`). The accessory firmware itself lives outside
+this repository and must implement the matching protocol.
+
 ---
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -224,28 +224,34 @@ Add required permissions to `Info.plist`:
 ### Accessory ranging (opt-in)
 
 Beyond phone-to-phone ranging, the library can range with a UWB **accessory** (a Qorvo/NXP
-board and similar). This is handled by profiles whose `exchange` is
-`ExchangeProtocol.AccessoryNotify`, and it is **off by default** because it requires **compatible
-accessory firmware** — the phone speaks a distinct, hardware-specific exchange to the device, not
-the standard peer-to-peer flow. Point a stock accessory at it and nothing will match.
+board and similar), handled by profiles whose `exchange` is `ExchangeProtocol.AccessoryNotify`.
+The two platforms use different accessory protocols:
 
-To enable it, add an accessory profile *and* set `enableAccessoryProtocol = true` on
-`BleDiscoveryConfig`:
+- **iOS** uses Apple's **standard** Nearby Interaction Accessory Protocol
+  (`NINearbyAccessoryConfiguration`), which works with stock accessory firmware. It is active
+  whenever an accessory profile is present — no opt-in needed.
+- **Android** uses a **bespoke** protocol (the phone acts as the FiRa controller and exchanges a
+  `UwbSessionConfig` over BLE). It only works against **compatible custom accessory firmware**, so
+  it is **off by default** and must be enabled explicitly.
+
+To enable the Android accessory path, add an accessory profile *and* set
+`enableAndroidAccessoryProtocol = true` on `BleDiscoveryConfig`:
 
 ```kotlin
 managerFactory.createBleManager(
     BleDiscoveryConfig(
         profiles = listOf(LOCAL_PROFILE, QorvoNearbyProfile), // QorvoNearbyProfile is app-owned
-        enableAccessoryProtocol = true,                       // deliberate opt-in; default false
+        enableAndroidAccessoryProtocol = true,                // Android-only opt-in; default false
     )
 )
 ```
 
-When the flag is left `false`, any `AccessoryNotify` profiles are ignored for discovery and
-exchange (a warning is logged), so peer-to-peer ranging is unaffected. See
+When the flag is left `false`, `AccessoryNotify` profiles are ignored for discovery **on Android**
+(a warning is logged), so Android phone-to-phone ranging is unaffected. The flag has no effect on
+iOS — its accessory path is Apple's standard protocol and is always available. See
 `AccessoryProfiles.kt` and `UwbDiscoveryViewModel` in the sample app for a working setup.
 
-**How the exchange works (per accessory):**
+**How the Android exchange works (per accessory):**
 
 1. Phone scans, discovers the accessory by its advertised UUID, and connects.
 2. Phone writes an **init** command (`ANDROID_ACCESSORY_INIT_COMMAND`).
@@ -256,9 +262,8 @@ exchange (a warning is logged), so peer-to-peer ranging is unaffected. See
 5. On stop, the phone sends a **stop** command and disconnects.
 
 The `UwbSessionConfig` wire format is little-endian to match the FiRa/UWB convention, so accessory
-firmware can lay its struct out natively. On iOS the equivalent path uses Apple's Nearby Interaction
-Accessory Protocol (`NINearbyAccessoryConfiguration`). The accessory firmware itself lives outside
-this repository and must implement the matching protocol.
+firmware can lay its struct out natively. The accessory firmware itself lives outside this
+repository and must implement the matching protocol.
 
 ---
 

--- a/composeApp/src/commonMain/kotlin/UwbDiscoveryViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/UwbDiscoveryViewModel.kt
@@ -29,9 +29,18 @@ class UwbDiscoveryViewModel(
 ) : ViewModel() {
     private val deviceDiscoveryManager = DeviceDiscoveryManager(
         managerFactory.createUwbManager(),
-        // Phone-to-phone over LOCAL_PROFILE; also scan for the Qorvo accessory (app-owned profile).
+        // Phone-to-phone over LOCAL_PROFILE, plus the Qorvo accessory (app-owned profile).
         managerFactory.createBleManager(
-            BleDiscoveryConfig(profiles = listOf(LOCAL_PROFILE, QorvoNearbyProfile))
+            BleDiscoveryConfig(
+                profiles = listOf(LOCAL_PROFILE, QorvoNearbyProfile),
+                // Opt in to the accessory (write-init / notify-back) protocol. It is OFF by default in
+                // the library because it only works against compatible accessory firmware (see the
+                // "Accessory ranging" section in the README). With it off, QorvoNearbyProfile above
+                // would be ignored and only phone-to-phone ranging would run. This sample turns it on
+                // so it can range with a flashed Qorvo/NXP board; drop this flag (or the profile) if
+                // you only need phone-to-phone.
+                enableAccessoryProtocol = true,
+            )
         )
     )
     var permissionState by mutableStateOf(PermissionState.NotDetermined)

--- a/composeApp/src/commonMain/kotlin/UwbDiscoveryViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/UwbDiscoveryViewModel.kt
@@ -33,13 +33,14 @@ class UwbDiscoveryViewModel(
         managerFactory.createBleManager(
             BleDiscoveryConfig(
                 profiles = listOf(LOCAL_PROFILE, QorvoNearbyProfile),
-                // Opt in to the accessory (write-init / notify-back) protocol. It is OFF by default in
-                // the library because it only works against compatible accessory firmware (see the
-                // "Accessory ranging" section in the README). With it off, QorvoNearbyProfile above
-                // would be ignored and only phone-to-phone ranging would run. This sample turns it on
-                // so it can range with a flashed Qorvo/NXP board; drop this flag (or the profile) if
-                // you only need phone-to-phone.
-                enableAccessoryProtocol = true,
+                // Opt in to the Android accessory protocol (the bespoke write-init / notify-back
+                // exchange). It is OFF by default in the library because on Android it only works
+                // against compatible custom accessory firmware (see the "Accessory ranging" section in
+                // the README). With it off, QorvoNearbyProfile above is ignored on Android and only
+                // phone-to-phone ranging runs; this sample turns it on so it can range with a flashed
+                // Qorvo/NXP board. It is Android-only: iOS ranges with the accessory via Apple's
+                // standard protocol whether or not this is set.
+                enableAndroidAccessoryProtocol = true,
             )
         )
     )

--- a/uwbmodule/src/androidMain/kotlin/BleManager.kt
+++ b/uwbmodule/src/androidMain/kotlin/BleManager.kt
@@ -121,7 +121,7 @@ actual class BleManager(
 
             var profile: UwbProfile? = null
             result.scanRecord?.serviceUuids?.forEach { uuid ->
-                config.profiles.forEach { p ->
+                config.activeProfiles.forEach { p ->
                     // Android normalizes 16-bit advertisements to the full base UUID, so a plain
                     // case-insensitive full-string compare matches both short and long forms.
                     if (profile == null && p.advertisedUuid.equals(uuid.toString(), ignoreCase = true)) {
@@ -276,8 +276,11 @@ actual class BleManager(
                 .setScanMode(ScanSettings.SCAN_MODE_LOW_LATENCY)
                 .build()
 
+            if (config.activeProfiles.size < config.profiles.size) {
+                Log.w(TAG, "Accessory profiles ignored: set BleDiscoveryConfig.enableAccessoryProtocol to use them")
+            }
             val filters: MutableList<ScanFilter> = mutableListOf()
-            config.profiles.forEach { profile ->
+            config.activeProfiles.forEach { profile ->
                 val scanFilter = ScanFilter.Builder()
                     .setServiceUuid(ParcelUuid(UUID.fromString(profile.advertisedUuid.uppercase())))
                     .build()

--- a/uwbmodule/src/androidMain/kotlin/BleManager.kt
+++ b/uwbmodule/src/androidMain/kotlin/BleManager.kt
@@ -277,7 +277,7 @@ actual class BleManager(
                 .build()
 
             if (config.activeProfiles.size < config.profiles.size) {
-                Log.w(TAG, "Accessory profiles ignored: set BleDiscoveryConfig.enableAccessoryProtocol to use them")
+                Log.w(TAG, "Accessory profiles ignored: set BleDiscoveryConfig.enableAndroidAccessoryProtocol to use them")
             }
             val filters: MutableList<ScanFilter> = mutableListOf()
             config.activeProfiles.forEach { profile ->

--- a/uwbmodule/src/commonMain/kotlin/UwbProfile.kt
+++ b/uwbmodule/src/commonMain/kotlin/UwbProfile.kt
@@ -130,25 +130,30 @@ const val NI_ACCESSORY_DID_STOP: Byte = 0x03
  * @property profiles the service profiles to scan for and host on the local GATT server.
  * @property advertiseProfile the [UwbProfile.name] of the profile this device advertises as its own
  *   identity. Must match one of [profiles].
- * @property enableAccessoryProtocol opt-in for the accessory (write-init / notify-back) exchange.
- *   Off by default: [ExchangeProtocol.AccessoryNotify] profiles only work against **compatible
- *   accessory firmware** (the app talks a distinct, hardware-specific protocol to the device), so it
- *   must be turned on deliberately. When false, any accessory profiles in [profiles] are ignored for
- *   discovery and exchange (see [activeProfiles]) — the app has to both add an accessory profile and
- *   set this flag. Peer-to-peer ([ExchangeProtocol.ReadWrite]) profiles are unaffected.
+ * @property enableAndroidAccessoryProtocol opt-in for the **Android** accessory protocol — the
+ *   bespoke write-init / notify-back exchange that carries a [UwbSessionConfig] and makes the phone
+ *   the FiRa controller. Off by default because it only works against **compatible custom accessory
+ *   firmware**, so it must be turned on deliberately. When false, [ExchangeProtocol.AccessoryNotify]
+ *   profiles are excluded from discovery on Android (see [activeProfiles]).
+ *
+ *   This flag is **Android-only**. On iOS, accessory ranging uses Apple's *standard* Nearby
+ *   Interaction Accessory Protocol (`NINearbyAccessoryConfiguration`), which works with stock
+ *   accessory firmware, so iOS honors any accessory profile whenever it is present regardless of this
+ *   flag. Peer-to-peer ([ExchangeProtocol.ReadWrite]) profiles are unaffected on both platforms.
  */
 data class BleDiscoveryConfig(
     val profiles: List<UwbProfile> = DEFAULT_PROFILES,
     val advertiseProfile: String = DEFAULT_PROFILES.first().name,
-    val enableAccessoryProtocol: Boolean = false,
+    val enableAndroidAccessoryProtocol: Boolean = false,
 ) {
     /**
-     * The profiles this device actually scans for and exchanges over. Identical to [profiles] when
-     * [enableAccessoryProtocol] is set; otherwise [ExchangeProtocol.AccessoryNotify] profiles are
-     * filtered out so the accessory protocol stays completely inert unless opted in.
+     * The profiles used for discovery on **Android** after applying [enableAndroidAccessoryProtocol]:
+     * identical to [profiles] when the flag is set, otherwise [ExchangeProtocol.AccessoryNotify]
+     * profiles are filtered out so the Android accessory protocol stays inert unless opted in. iOS
+     * uses [profiles] directly (its accessory path is the standard Apple protocol).
      */
     val activeProfiles: List<UwbProfile>
-        get() = if (enableAccessoryProtocol) {
+        get() = if (enableAndroidAccessoryProtocol) {
             profiles
         } else {
             profiles.filter { it.exchange != ExchangeProtocol.AccessoryNotify }

--- a/uwbmodule/src/commonMain/kotlin/UwbProfile.kt
+++ b/uwbmodule/src/commonMain/kotlin/UwbProfile.kt
@@ -130,8 +130,27 @@ const val NI_ACCESSORY_DID_STOP: Byte = 0x03
  * @property profiles the service profiles to scan for and host on the local GATT server.
  * @property advertiseProfile the [UwbProfile.name] of the profile this device advertises as its own
  *   identity. Must match one of [profiles].
+ * @property enableAccessoryProtocol opt-in for the accessory (write-init / notify-back) exchange.
+ *   Off by default: [ExchangeProtocol.AccessoryNotify] profiles only work against **compatible
+ *   accessory firmware** (the app talks a distinct, hardware-specific protocol to the device), so it
+ *   must be turned on deliberately. When false, any accessory profiles in [profiles] are ignored for
+ *   discovery and exchange (see [activeProfiles]) — the app has to both add an accessory profile and
+ *   set this flag. Peer-to-peer ([ExchangeProtocol.ReadWrite]) profiles are unaffected.
  */
 data class BleDiscoveryConfig(
     val profiles: List<UwbProfile> = DEFAULT_PROFILES,
     val advertiseProfile: String = DEFAULT_PROFILES.first().name,
-)
+    val enableAccessoryProtocol: Boolean = false,
+) {
+    /**
+     * The profiles this device actually scans for and exchanges over. Identical to [profiles] when
+     * [enableAccessoryProtocol] is set; otherwise [ExchangeProtocol.AccessoryNotify] profiles are
+     * filtered out so the accessory protocol stays completely inert unless opted in.
+     */
+    val activeProfiles: List<UwbProfile>
+        get() = if (enableAccessoryProtocol) {
+            profiles
+        } else {
+            profiles.filter { it.exchange != ExchangeProtocol.AccessoryNotify }
+        }
+}

--- a/uwbmodule/src/commonMain/kotlin/UwbSessionConfig.kt
+++ b/uwbmodule/src/commonMain/kotlin/UwbSessionConfig.kt
@@ -179,20 +179,18 @@ data class UwbSessionConfig(
             } else {
                 null
             }
-            return if(sessionId == 0)
-                null
-            else {
-                UwbSessionConfig(
-                    sessionId = sessionId,
-                    channel = channel,
-                    preambleIndex = preambleIndex,
-                    uwbAddress = uwbAddress,
-                    discoveryToken = discoveryToken,
-                    sessionKey = sessionKey,
-                    accessoryData = accessoryData,
-                    isAccessoryDevice = accessoryDevice
-                )
-            }
+            // Note: sessionId == 0 is a valid value (iOS local configs use it, and the controller
+            // assigns the real id at ranging time), so it must not be treated as "not a config".
+            return UwbSessionConfig(
+                sessionId = sessionId,
+                channel = channel,
+                preambleIndex = preambleIndex,
+                uwbAddress = uwbAddress,
+                discoveryToken = discoveryToken,
+                sessionKey = sessionKey,
+                accessoryData = accessoryData,
+                isAccessoryDevice = accessoryDevice
+            )
         }
 
         // Little-endian readers (least-significant byte first), matching toByteArray.

--- a/uwbmodule/src/commonTest/kotlin/com/dustedrob/uwb/UwbProfileTest.kt
+++ b/uwbmodule/src/commonTest/kotlin/com/dustedrob/uwb/UwbProfileTest.kt
@@ -4,6 +4,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlin.test.assertSame
+import kotlin.test.assertTrue
 
 class UwbProfileTest {
 
@@ -76,5 +77,48 @@ class UwbProfileTest {
             enableAccessoryProtocol = true,
         )
         assertEquals(listOf(LOCAL_PROFILE, accessoryProfile), config.activeProfiles)
+    }
+
+    @Test
+    fun activeProfilesFiltersEveryAccessoryProfileWhenDisabled() {
+        val secondAccessory = ServiceEntry(
+            name = "accessory2",
+            discoveryServiceUuid = "6E400001-B5A3-F393-E0A9-E50E24DCCA9E",
+            writeToUuid = "6E400002-B5A3-F393-E0A9-E50E24DCCA9E",
+            notifyFromUuid = "6E400003-B5A3-F393-E0A9-E50E24DCCA9E",
+            exchange = ExchangeProtocol.AccessoryNotify,
+        )
+        val config = BleDiscoveryConfig(
+            profiles = listOf(accessoryProfile, LOCAL_PROFILE, secondAccessory),
+        )
+        // Only the ReadWrite profile survives, and original order is preserved.
+        assertEquals(listOf(LOCAL_PROFILE), config.activeProfiles)
+    }
+
+    @Test
+    fun activeProfilesEmptyWhenAllAccessoryAndDisabled() {
+        val config = BleDiscoveryConfig(
+            profiles = listOf(accessoryProfile),
+            advertiseProfile = accessoryProfile.name,
+        )
+        assertTrue(config.activeProfiles.isEmpty())
+    }
+
+    @Test
+    fun activeProfilesEqualsProfilesForPeerToPeerOnly() {
+        // No accessory profiles present: the flag makes no difference.
+        val profiles = listOf(LOCAL_PROFILE)
+        assertEquals(profiles, BleDiscoveryConfig(profiles = profiles).activeProfiles)
+        assertEquals(
+            profiles,
+            BleDiscoveryConfig(profiles = profiles, enableAccessoryProtocol = true).activeProfiles,
+        )
+    }
+
+    @Test
+    fun defaultConfigHasNoAccessoryProfiles() {
+        // The vendor-free default is peer-to-peer only, so activeProfiles == profiles regardless.
+        val config = BleDiscoveryConfig()
+        assertEquals(config.profiles, config.activeProfiles)
     }
 }

--- a/uwbmodule/src/commonTest/kotlin/com/dustedrob/uwb/UwbProfileTest.kt
+++ b/uwbmodule/src/commonTest/kotlin/com/dustedrob/uwb/UwbProfileTest.kt
@@ -66,7 +66,7 @@ class UwbProfileTest {
     fun accessoryProtocolDisabledByDefault() {
         val config = BleDiscoveryConfig(profiles = listOf(LOCAL_PROFILE, accessoryProfile))
         // Off by default: accessory profiles are filtered out of the active set.
-        assertEquals(false, config.enableAccessoryProtocol)
+        assertEquals(false, config.enableAndroidAccessoryProtocol)
         assertEquals(listOf(LOCAL_PROFILE), config.activeProfiles)
     }
 
@@ -74,7 +74,7 @@ class UwbProfileTest {
     fun accessoryProtocolEnabledIncludesAccessoryProfiles() {
         val config = BleDiscoveryConfig(
             profiles = listOf(LOCAL_PROFILE, accessoryProfile),
-            enableAccessoryProtocol = true,
+            enableAndroidAccessoryProtocol = true,
         )
         assertEquals(listOf(LOCAL_PROFILE, accessoryProfile), config.activeProfiles)
     }
@@ -111,7 +111,7 @@ class UwbProfileTest {
         assertEquals(profiles, BleDiscoveryConfig(profiles = profiles).activeProfiles)
         assertEquals(
             profiles,
-            BleDiscoveryConfig(profiles = profiles, enableAccessoryProtocol = true).activeProfiles,
+            BleDiscoveryConfig(profiles = profiles, enableAndroidAccessoryProtocol = true).activeProfiles,
         )
     }
 

--- a/uwbmodule/src/commonTest/kotlin/com/dustedrob/uwb/UwbProfileTest.kt
+++ b/uwbmodule/src/commonTest/kotlin/com/dustedrob/uwb/UwbProfileTest.kt
@@ -52,4 +52,29 @@ class UwbProfileTest {
         assertEquals("11000000-27B9-42F0-82AA-2E951747BBF9", accessory.advertisedUuid)
         assertEquals(ExchangeProtocol.AccessoryNotify, accessory.exchange)
     }
+
+    private val accessoryProfile = ServiceEntry(
+        name = "accessory",
+        discoveryServiceUuid = "2E938FD0-6A61-11ED-A1EB-0242AC120002",
+        writeToUuid = "2E93998A-6A61-11ED-A1EB-0242AC120002",
+        notifyFromUuid = "2E939AF2-6A61-11ED-A1EB-0242AC120002",
+        exchange = ExchangeProtocol.AccessoryNotify,
+    )
+
+    @Test
+    fun accessoryProtocolDisabledByDefault() {
+        val config = BleDiscoveryConfig(profiles = listOf(LOCAL_PROFILE, accessoryProfile))
+        // Off by default: accessory profiles are filtered out of the active set.
+        assertEquals(false, config.enableAccessoryProtocol)
+        assertEquals(listOf(LOCAL_PROFILE), config.activeProfiles)
+    }
+
+    @Test
+    fun accessoryProtocolEnabledIncludesAccessoryProfiles() {
+        val config = BleDiscoveryConfig(
+            profiles = listOf(LOCAL_PROFILE, accessoryProfile),
+            enableAccessoryProtocol = true,
+        )
+        assertEquals(listOf(LOCAL_PROFILE, accessoryProfile), config.activeProfiles)
+    }
 }

--- a/uwbmodule/src/commonTest/kotlin/com/dustedrob/uwb/UwbSessionConfigTest.kt
+++ b/uwbmodule/src/commonTest/kotlin/com/dustedrob/uwb/UwbSessionConfigTest.kt
@@ -217,4 +217,104 @@ class UwbSessionConfigTest {
         assertNull(restored.accessoryData)
         assertTrue(restored.sessionKey!!.size == 8)
     }
+
+    @Test
+    fun sessionIdZeroRoundTrips() {
+        // Regression guard: fromByteArray must NOT treat sessionId == 0 as "not a config".
+        val config = UwbSessionConfig(
+            sessionId = 0,
+            channel = 9,
+            preambleIndex = 10,
+            uwbAddress = byteArrayOf(0x0A, 0x0B),
+        )
+        val restored = UwbSessionConfig.fromByteArray(config.toByteArray())
+        assertNotNull(restored)
+        assertEquals(0, restored.sessionId)
+        assertEquals(config, restored)
+    }
+
+    @Test
+    fun iosStyleConfigRoundTrips() {
+        // iOS local configs use sessionId = 0, empty address, and a discovery token; this must parse
+        // on the receiving (e.g. Android) side.
+        val token = ByteArray(64) { (it * 3).toByte() }
+        val config = UwbSessionConfig(
+            sessionId = 0,
+            channel = 0,
+            preambleIndex = 0,
+            uwbAddress = ByteArray(0),
+            discoveryToken = token,
+        )
+        val restored = UwbSessionConfig.fromByteArray(config.toByteArray())
+        assertNotNull(restored)
+        assertEquals(0, restored.sessionId)
+        assertTrue(token.contentEquals(restored.discoveryToken!!))
+        assertNull(restored.sessionKey)
+        assertNull(restored.accessoryData)
+    }
+
+    @Test
+    fun roundtripWithAllTrailers() {
+        val token = byteArrayOf(0x01, 0x02, 0x03)
+        val key = ByteArray(8) { (it + 1).toByte() }
+        val acc = ByteArray(20) { (0xF0 - it).toByte() }
+        val config = UwbSessionConfig(
+            sessionId = 4242,
+            channel = 9,
+            preambleIndex = 11,
+            uwbAddress = byteArrayOf(0x86.toByte(), 0xE4.toByte()),
+            discoveryToken = token,
+            sessionKey = key,
+            accessoryData = acc,
+        )
+        val restored = UwbSessionConfig.fromByteArray(config.toByteArray())
+        assertNotNull(restored)
+        assertEquals(config, restored)
+        assertTrue(token.contentEquals(restored.discoveryToken!!))
+        assertTrue(key.contentEquals(restored.sessionKey!!))
+        assertTrue(acc.contentEquals(restored.accessoryData!!))
+    }
+
+    @Test
+    fun negativeSessionIdRoundTripsLittleEndian() {
+        // High-bit-set values must survive the little-endian read/write symmetrically.
+        for (sid in intArrayOf(-1, Int.MIN_VALUE, 0x80000000.toInt(), -123456)) {
+            val config = UwbSessionConfig(sid, 9, 10, byteArrayOf(1, 2))
+            val restored = UwbSessionConfig.fromByteArray(config.toByteArray())
+            assertNotNull(restored)
+            assertEquals(sid, restored.sessionId)
+        }
+    }
+
+    @Test
+    fun emptyAccessoryDataParsesAsNull() {
+        // A zero-length trailer is indistinguishable from absent, so it comes back null.
+        val config = UwbSessionConfig(1, 2, 3, byteArrayOf(9), accessoryData = ByteArray(0))
+        val restored = UwbSessionConfig.fromByteArray(config.toByteArray())
+        assertNotNull(restored)
+        assertNull(restored.accessoryData)
+    }
+
+    @Test
+    fun truncatedKeyTrailerParsesConfigWithNullKey() {
+        // Payload declares an 8-byte key trailer but includes no key bytes. Parsing must not crash
+        // or reject the config; the trailer is simply treated as absent.
+        val sid = 5
+        val ch = 9
+        val pre = 10
+        val truncated = byteArrayOf(
+            1, // version
+            sid.toByte(), (sid shr 8).toByte(), (sid shr 16).toByte(), (sid shr 24).toByte(),
+            ch.toByte(), (ch shr 8).toByte(), (ch shr 16).toByte(), (ch shr 24).toByte(),
+            pre.toByte(), (pre shr 8).toByte(), (pre shr 16).toByte(), (pre shr 24).toByte(),
+            0, 0, // addr size = 0
+            0, 0, // token size = 0
+            8, 0, // key size = 8, but no key bytes follow
+        )
+        val restored = UwbSessionConfig.fromByteArray(truncated)
+        assertNotNull(restored)
+        assertEquals(sid, restored.sessionId)
+        assertNull(restored.sessionKey)
+        assertNull(restored.accessoryData)
+    }
 }

--- a/uwbmodule/src/iosMain/kotlin/BleManager.kt
+++ b/uwbmodule/src/iosMain/kotlin/BleManager.kt
@@ -127,7 +127,7 @@ actual class BleManager(
 
                 // Match advertised service UUIDs against our profiles. CBUUID equality normalizes
                 // 16-bit (e.g. FFF0) vs full 128-bit base UUIDs, so no string slicing is needed.
-                config.activeProfiles.forEach { p ->
+                config.profiles.forEach { p ->
                     val target = CBUUID.UUIDWithString(p.advertisedUuid)
                     if (serviceUuids.any { it == target }) {
                         profile = p
@@ -389,12 +389,10 @@ actual class BleManager(
 
     // ---- Public API: Scanning ----
 
-    private fun scanServiceUuids(): List<CBUUID> {
-        if (config.activeProfiles.size < config.profiles.size) {
-            NSLog("BleManager: accessory profiles ignored, set BleDiscoveryConfig.enableAccessoryProtocol to use them")
-        }
-        return config.activeProfiles.map { CBUUID.UUIDWithString(it.advertisedUuid) }
-    }
+    // iOS uses all profiles: accessory ranging here is Apple's standard NI Accessory Protocol,
+    // which is not gated by BleDiscoveryConfig.enableAndroidAccessoryProtocol (that flag is Android-only).
+    private fun scanServiceUuids(): List<CBUUID> =
+        config.profiles.map { CBUUID.UUIDWithString(it.advertisedUuid) }
 
     actual fun startScanning() {
         val central = centralManager ?: CBCentralManager(centralDelegate, null).also {

--- a/uwbmodule/src/iosMain/kotlin/BleManager.kt
+++ b/uwbmodule/src/iosMain/kotlin/BleManager.kt
@@ -127,7 +127,7 @@ actual class BleManager(
 
                 // Match advertised service UUIDs against our profiles. CBUUID equality normalizes
                 // 16-bit (e.g. FFF0) vs full 128-bit base UUIDs, so no string slicing is needed.
-                config.profiles.forEach { p ->
+                config.activeProfiles.forEach { p ->
                     val target = CBUUID.UUIDWithString(p.advertisedUuid)
                     if (serviceUuids.any { it == target }) {
                         profile = p
@@ -389,8 +389,12 @@ actual class BleManager(
 
     // ---- Public API: Scanning ----
 
-    private fun scanServiceUuids(): List<CBUUID> =
-        config.profiles.map { CBUUID.UUIDWithString(it.advertisedUuid) }
+    private fun scanServiceUuids(): List<CBUUID> {
+        if (config.activeProfiles.size < config.profiles.size) {
+            NSLog("BleManager: accessory profiles ignored, set BleDiscoveryConfig.enableAccessoryProtocol to use them")
+        }
+        return config.activeProfiles.map { CBUUID.UUIDWithString(it.advertisedUuid) }
+    }
 
     actual fun startScanning() {
         val central = centralManager ?: CBCentralManager(centralDelegate, null).also {


### PR DESCRIPTION
Adds `BleDiscoveryConfig.enableAccessoryProtocol` (default **off**) so the accessory (write-init / notify-back) protocol is a deliberate opt-in rather than always-on whenever an accessory profile is present. That protocol only works against compatible custom accessory firmware, so it should not be active by default.

## Opt-in
- New `enableAccessoryProtocol: Boolean = false` on `BleDiscoveryConfig`, plus a computed `activeProfiles` that filters out `ExchangeProtocol.AccessoryNotify` profiles when off.
- Both `BleManager`s scan/match on `activeProfiles` and log a warning when accessory profiles are dropped because the flag is off. Peer-to-peer (`ReadWrite`) is unaffected; the GATT server already excluded accessory profiles.
- Whole-feature toggle: applies to both Android and iOS accessory paths.

## Bug fix
- Removes the `if (sessionId == 0) null` check added to `fromByteArray` in #45. `sessionId == 0` is a valid value (iOS local configs use it, and the controller assigns the real id at ranging time), so that check silently broke iOS config parsing and failed a unit test. Fixed and guarded with a regression test.

## Docs + sample
- New "Accessory ranging (opt-in)" README section: how to enable it, the default-off rationale (custom firmware), the full init -> notify -> configure-and-start -> stop exchange, and the little-endian / iOS-accessory notes. KDoc on the new flag and `activeProfiles`.
- Sample app sets `enableAccessoryProtocol = true` with a comment explaining what it does and that it needs a flashed board.

## Tests
- `UwbSessionConfigTest`: added `sessionId == 0` and iOS-style round-trips (regression guards), all-trailers, negative/high-bit little-endian symmetry, empty and truncated trailers.
- `UwbProfileTest`: added `activeProfiles` filtering cases (multiple accessory profiles, all-accessory, peer-to-peer no-op, default config).
- 30 tests across both files, green on Android and iOS-sim. Both platforms + the sample app compile.
