### PR TITLE
multi-session on accessory_ranging

### DIFF
--- a/composeApp/src/commonMain/kotlin/App.kt
+++ b/composeApp/src/commonMain/kotlin/App.kt
@@ -416,6 +416,7 @@ private fun LocalDeviceInfoPreview() {
     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
         LocalDeviceInfo(
             config = UwbSessionConfig(
+                scope = 0,
                 sessionId = 42,
                 channel = 9,
                 preambleIndex = 10,

--- a/composeApp/src/commonMain/kotlin/UwbDiscoveryViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/UwbDiscoveryViewModel.kt
@@ -128,6 +128,6 @@ class UwbDiscoveryViewModel(
 
     override fun onCleared() {
         super.onCleared()
-        deviceDiscoveryManager.cleanup()
+        //deviceDiscoveryManager.cleanup()
     }
 }

--- a/uwbmodule/src/androidMain/kotlin/MultiplatformUwbManager.android.kt
+++ b/uwbmodule/src/androidMain/kotlin/MultiplatformUwbManager.android.kt
@@ -6,6 +6,7 @@ import androidx.core.uwb.RangingResult
 import androidx.core.uwb.UwbAddress
 import androidx.core.uwb.UwbClientSessionScope
 import androidx.core.uwb.UwbComplexChannel
+import androidx.core.uwb.UwbControleeSessionScope
 import androidx.core.uwb.UwbControllerSessionScope
 import androidx.core.uwb.UwbDevice
 import androidx.core.uwb.UwbManager
@@ -33,12 +34,13 @@ actual class MultiplatformUwbManager(private val androidUwbManager: UwbManager? 
     private val coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
 
     /** The session scope obtained during [initialize], which provides our local UWB address. */
-    private var sessionScope: UwbClientSessionScope? = null
+    //private var sessionScope: UwbClientSessionScope? = null
 
     /** Active ranging coroutine jobs, keyed by peer ID. Cancel to stop ranging. */
     private val activeJobs = mutableMapOf<String, Job>()
 
-    private var controllerScope: UwbControllerSessionScope? = null
+
+    private val activeSessions = mutableMapOf<String, UwbSessionConfig>()
 
     /**
      * Our 8-byte static-STS session key, generated once and reused for the lifetime
@@ -59,34 +61,36 @@ actual class MultiplatformUwbManager(private val androidUwbManager: UwbManager? 
             return
         }
         try {
-            val scope =
-                androidUwbManager.controllerSessionScope()// androidUwbManager.controleeSessionScope()
-            sessionScope = scope
-            // need this for ranging wit accessory, can't create later
-            controllerScope = androidUwbManager.controllerSessionScope()
 
-            val capabilities = scope.rangingCapabilities
+            //val scope = androidUwbManager.controllerSessionScope()// androidUwbManager.controleeSessionScope()
+            //sessionScope = scope
+            // need this for ranging wit accessory, can't create later
+            //controllerScope = androidUwbManager.controllerSessionScope()
+
+            val capabilities = androidUwbManager.controllerSessionScope().rangingCapabilities
             if (!capabilities.isDistanceSupported) {
                 errorCallback?.invoke("UWB distance ranging not supported")
             }
-            Log.d(TAG, "UWB initialized. Local address: ${scope.localAddress}")
+            //Log.d(TAG, "UWB initialized. Local address: ${scope.localAddress}")
         } catch (e: Exception) {
             errorCallback?.invoke("Failed to initialize UWB: ${e.message}")
         }
     }
 
-    actual fun getLocalConfig(isAccessory: Boolean): UwbSessionConfig? {
-        val scope = if (isAccessory) {
-            controllerScope
+    actual suspend fun getLocalConfig(isAccessory: Boolean ): UwbSessionConfig? {
+        val localScope = if(isAccessory){
+            androidUwbManager?.controllerSessionScope()
         } else {
-            sessionScope
+            androidUwbManager?.controleeSessionScope()
         }
-        val localAddress = scope?.localAddress?.address
+
+        val localAddress = localScope?.localAddress?.address
 
         // Generate a session ID from our address for deterministic agreement.
         // During config exchange, the initiator's sessionId is used by convention
         // (the peer with the lexicographically smaller address initiates).
-        val sessionId = localAddress?.fold(0) { acc, b -> acc * 31 + (b.toInt() and 0xFF) }
+
+        val sessionId:Int? = localAddress?.fold(0) { acc, b -> acc * 31 + (b.toInt() and 0xFF) }
 
         // Generate the static-STS key lazily and cache it, so the key we send over
         // BLE is the same one we compare/use when ranging starts.
@@ -96,50 +100,46 @@ actual class MultiplatformUwbManager(private val androidUwbManager: UwbManager? 
 
         Log.d(TAG, "phone address is ${localAddress?.toHexString()}")
 
-
-        return if (sessionId != null) {
-            UwbSessionConfig(
-                sessionId = sessionId,
-                channel = DEFAULT_CHANNEL,
-                preambleIndex = DEFAULT_PREAMBLE_INDEX,
-                uwbAddress = localAddress,
-                discoveryToken = null,
-                sessionKey = key,
-            )
+        return if(sessionId !=0 ) {
+            localScope?.let {
+                sessionId?.let { it1 ->
+                    UwbSessionConfig(
+                        scope = it,
+                        sessionId = it1,
+                        channel = DEFAULT_CHANNEL,
+                        preambleIndex = DEFAULT_PREAMBLE_INDEX,
+                        uwbAddress = localAddress,
+                        discoveryToken = null,
+                        sessionKey = key,
+                    )
+                }
+            }
         } else {
             null
         }
     }
 
-    actual fun startRanging(peerId: String, remoteConfig: UwbSessionConfig) {
-        val scope = if (remoteConfig.isAccessoryDevice) {
-            controllerScope
-        } else {
-            sessionScope
-        }
-        if (scope == null) {
-            errorCallback?.invoke("UWB not initialized. Call initialize() first.")
-            return
-        }
-        val localConfig = getLocalConfig(remoteConfig.isAccessoryDevice)
-        // The phone runs a controller session (see MultiplatformUwbManager.controlerSessionScope),
+    actual suspend fun startRanging(peerId: String, remoteConfig: UwbSessionConfig) {
+
+        // get the config we should use for our role
+        val sessionConfig = getLocalConfig(remoteConfig.isAccessoryDevice)
+        // add it to the remote config, as it wasn't used til now
+        val tempRemoteConfig = remoteConfig.copy(scope = sessionConfig?.scope as UwbClientSessionScope)
+        // The phone runs a controller session (see MultiplatformUwbManager.controllerSessionScope) for accessories,
         // so in FiRa terms the phone is the controller and OWNS the session parameters
         // (sessionId + static-STS key + channel + preamble).
-        val remoteConfigAdjusted = if (remoteConfig.isAccessoryDevice) {
-            remoteConfig.copy(
-                sessionId = localConfig!!.sessionId,
-                sessionKey = localConfig.sessionKey
-            )
+        val remoteConfigAdjusted = if(remoteConfig.isAccessoryDevice){
+            tempRemoteConfig.copy(sessionId= sessionConfig.sessionId, sessionKey= sessionConfig.sessionKey)
         } else {
-            remoteConfig
+            tempRemoteConfig
         }
         Log.d(
             TAG,
-     "config merged: session=${remoteConfigAdjusted.sessionId?.toHexString()} " +
-            "ch=${remoteConfigAdjusted.channel} preamble=${remoteConfigAdjusted.preambleIndex} " +
-            "key=${remoteConfigAdjusted.sessionKey?.toHexString()} " +
-            "remoteAddr=${remoteConfigAdjusted.uwbAddress.toHexString()} " +
-            "localAddr=${localConfig!!.uwbAddress.toHexString()}"
+            "accessory config merged: session=${remoteConfigAdjusted.sessionId?.toHexString()} " +
+                    "ch=${remoteConfigAdjusted.channel} preamble=${remoteConfigAdjusted.preambleIndex} " +
+                    "key=${remoteConfigAdjusted.sessionKey?.toHexString()} " +
+                    "accessoryAddr=${remoteConfigAdjusted.uwbAddress.toHexString()} " +
+                    "localAddr=${sessionConfig.uwbAddress.toHexString()}"
         )
         // Cancel any existing ranging job for this peer
         activeJobs[peerId]?.cancel()
@@ -155,14 +155,12 @@ actual class MultiplatformUwbManager(private val androidUwbManager: UwbManager? 
                 // exchange, so they independently compute the same values.
 
                 // unless it's an accessory device, in which case we should always use the remoteConfig
-                //val localConfig = getLocalConfig()
-                Log.d(TAG, "accessory=${remoteConfigAdjusted.isAccessoryDevice}")
-                val agreed = if (!remoteConfigAdjusted.isAccessoryDevice && compareAddresses(
-                        localConfig.uwbAddress,
-                        remoteConfigAdjusted.uwbAddress
-                    ) <= 0
+
+                // this doesn't work in real life
+                Log.d(TAG,"accessory=${remoteConfigAdjusted.isAccessoryDevice}")
+                val agreed = if (!remoteConfigAdjusted.isAccessoryDevice && compareAddresses(sessionConfig.uwbAddress, remoteConfigAdjusted.uwbAddress) <= 0
                 ) {
-                    localConfig
+                    sessionConfig
                 } else {
                     remoteConfigAdjusted
                 }
@@ -183,37 +181,35 @@ actual class MultiplatformUwbManager(private val androidUwbManager: UwbManager? 
                 val peerDevice = UwbDevice(peerAddress)
                 Log.d(TAG, "ranging peer device address is ${agreed.uwbAddress.toHexString()}")
 
-                val rangingParameters: RangingParameters? = agreed.sessionId?.let {
-                    RangingParameters(
-                        uwbConfigType = RangingParameters.CONFIG_UNICAST_DS_TWR,
-                        sessionId = it,
-                        subSessionId = 0,
-                        sessionKeyInfo = agreed.sessionKey,
-                        subSessionKeyInfo = null,
-                        complexChannel = UwbComplexChannel(
-                            channel = agreed.channel,
-                            preambleIndex = agreed.preambleIndex
-                        ),
-                        peerDevices = listOf(peerDevice),
-                        updateRateType = RangingParameters.RANGING_UPDATE_RATE_AUTOMATIC
-                    )
-                }
+                val rangingParameters: RangingParameters = RangingParameters(
+                    uwbConfigType = RangingParameters.CONFIG_UNICAST_DS_TWR,
+                    sessionId = agreed.sessionId,
+                    subSessionId = 0,
+                    sessionKeyInfo = agreed.sessionKey,
+                    subSessionKeyInfo = null,
+                    complexChannel = UwbComplexChannel(
+                        channel = agreed.channel,
+                        preambleIndex = agreed.preambleIndex
+                    ),
+                    peerDevices = listOf(peerDevice),
+                    updateRateType = RangingParameters.RANGING_UPDATE_RATE_AUTOMATIC
+                )
 
                 Log.d(
                     TAG,
-                    "Starting ranging with $peerId — session=${agreed.sessionId?.toHexString()} ch=${agreed.channel} pai=${agreed.preambleIndex}  address=${agreed.uwbAddress.toHexString()}"
+                    "Starting ranging with $peerId — session=${agreed.sessionId.toHexString()} ch=${agreed.channel} pai=${agreed.preambleIndex}  address=${agreed.uwbAddress.toHexString()}"
                 )
 
                 // if this is an accessory, send the config it should use now, as we have done all the pre-checking
-                if (agreed.isAccessoryDevice) {
-                    val message =
-                        byteArrayOf(ANDROID_ACCESSORY_CONFIGURE_AND_START) + localConfig.toByteArray()
+                if(agreed.isAccessoryDevice) {
+                    val message = byteArrayOf(ANDROID_ACCESSORY_CONFIGURE_AND_START)+ sessionConfig.toByteArray()
                     Log.d(TAG, "sending config data message to accessory=${message.toHexString()}")
-                    localConfig.toByteArray().let { sendToPeerCallback?.invoke(peerId, message) }
+                    sessionConfig.toByteArray().let { sendToPeerCallback?.invoke(peerId, message) }
                 }
 
 
-                rangingParameters?.let { scope.prepareSession(it) }
+
+                rangingParameters.let { ((activeSessions[peerId] as UwbSessionConfig).scope as UwbClientSessionScope).prepareSession(it) }
                     ?.catch { exception ->
                         errorCallback?.invoke("Ranging failed for $peerId: ${exception.message}")
                     }
@@ -221,7 +217,7 @@ actual class MultiplatformUwbManager(private val androidUwbManager: UwbManager? 
                         Log.d(TAG, "in collect")
                         when (result) {
                             is RangingResult.RangingResultPosition -> {
-                                Log.d(TAG, "Ranging position report")
+                                Log.d(TAG,"Ranging position report")
                                 val distance = result.position.distance?.value
                                 if (distance != null) {
                                     rangingCallback?.invoke(
@@ -233,32 +229,35 @@ actual class MultiplatformUwbManager(private val androidUwbManager: UwbManager? 
                                 }
                             }
 
-                            is RangingResult.RangingResultInitialized -> {
-                                Log.d(TAG, "Ranging init")
+                            is RangingResult.RangingResultInitialized ->{
+                                Log.d(TAG,"Ranging init")
                             }
 
                             is RangingResult.RangingResultPeerDisconnected -> {
-                                Log.d(TAG, "peer disconnected")
+                                Log.d(TAG,"peer disconnected")
                                 errorCallback?.invoke("Peer $peerId disconnected")
                                 activeJobs.remove(peerId)
                             }
 
-                            else -> {
-                                Log.d(TAG, "unexpected ranging result ${result}")
+                            else ->{
+                                Log.d(TAG,"unexpected ranging result ${result}")
                             }
                         }
                     }
-            } catch (e: Exception) {
-                Log.d(TAG, "Ranging startup failed, ${e.message}")
-                errorCallback?.invoke("Failed to start ranging with $peerId: ${e.message}")
+                } catch (e: Exception) {
+                    Log.d(TAG,"Ranging startup failed, ${e.message}")
+                    errorCallback?.invoke("Failed to start ranging with $peerId: ${e.message}")
+                }
+                Log.d(TAG,"Ranging active (maybe)")
             }
-            Log.d(TAG, "Ranging active (maybe)")
+            Log.d(TAG,"Ranging process starting for peer ${peerId}")
+            activeJobs[peerId] = job
+            activeSessions[peerId] = sessionConfig
         }
-        Log.d(TAG, "Ranging process starting for peer ${peerId}")
-        activeJobs[peerId] = job
-    }
 
-    actual fun stopRanging(peerId: String) {
+    actual suspend fun stopRanging(peerId: String) {
+
+        activeSessions.remove((peerId))
         activeJobs.remove(peerId)?.let { job ->
             job.cancel()
             Log.d(TAG, "Stopped ranging with $peerId")
@@ -291,10 +290,11 @@ actual class MultiplatformUwbManager(private val androidUwbManager: UwbManager? 
     }
 
     /** Stop all sessions and clean up resources. */
-    actual fun cleanup() {
+    actual suspend fun cleanup() {
         activeJobs.values.forEach { it.cancel() }
         activeJobs.clear()
-        sessionScope = null
+        activeSessions.clear()
         coroutineScope.cancel()
+        }
     }
-}
+

--- a/uwbmodule/src/commonMain/kotlin/DeviceDiscoveryManager.kt
+++ b/uwbmodule/src/commonMain/kotlin/DeviceDiscoveryManager.kt
@@ -108,7 +108,7 @@ class DeviceDiscoveryManager(
     }
 
     /** Get the local UWB config (address, session ID, channel) for display. */
-    fun getLocalConfig(): UwbSessionConfig? = multiplatformUwbManager.getLocalConfig()
+    suspend fun getLocalConfig(): UwbSessionConfig? = multiplatformUwbManager.getLocalConfig(false)
 
     suspend fun startScanning() {
         if (isScanning) return
@@ -118,7 +118,7 @@ class DeviceDiscoveryManager(
         multiplatformUwbManager.initialize()
 
         // Start GATT server so peers can exchange configs with us
-        val localConfig = multiplatformUwbManager.getLocalConfig()
+        val localConfig = multiplatformUwbManager.getLocalConfig(false)
         if (localConfig != null) {
             bleManager.startGattServer(localConfig)
         }
@@ -136,7 +136,7 @@ class DeviceDiscoveryManager(
         }
     }
 
-    fun stopScanning() {
+    suspend fun stopScanning() {
         if (!isScanning) return
         isScanning = false
 
@@ -169,7 +169,7 @@ class DeviceDiscoveryManager(
      * Clean up all resources, including UWB manager and BLE manager.
      * Should be called when the manager is no longer needed (e.g., in ViewModel.onCleared).
      */
-    fun cleanup() {
+    suspend fun cleanup() {
         stopScanning()
         multiplatformUwbManager.cleanup()
         bleManager.cleanup()
@@ -218,7 +218,7 @@ class DeviceDiscoveryManager(
 
         // Initiate config exchange if not already done/pending
         if (id !in exchangedPeers && id !in pendingExchanges) {
-            val localConfig = multiplatformUwbManager.getLocalConfig()
+            val localConfig = multiplatformUwbManager.getLocalConfig(false)
             if (localConfig != null) {
                 pendingExchanges.add(id)
                 emitEvent(EventType.ConfigExchangeStarted, id, "Starting GATT config exchange")

--- a/uwbmodule/src/commonMain/kotlin/MultiplatformUwbManager.kt
+++ b/uwbmodule/src/commonMain/kotlin/MultiplatformUwbManager.kt
@@ -20,7 +20,7 @@ expect class MultiplatformUwbManager {
      * On Android: contains local UWB address, proposed session ID, channel, preamble.
      * On iOS: contains serialized NI discovery token.
      */
-    fun getLocalConfig(isAccessory:Boolean= false): UwbSessionConfig?
+    suspend fun getLocalConfig(isAccessory:Boolean): UwbSessionConfig?
 
     /**
      * Start ranging with a peer using exchanged configurations.
@@ -28,10 +28,10 @@ expect class MultiplatformUwbManager {
      * @param peerId Identifier for the peer (BLE device address/UUID).
      * @param remoteConfig The peer's [UwbSessionConfig] received via BLE GATT exchange.
      */
-    fun startRanging(peerId: String, remoteConfig: UwbSessionConfig)
+    suspend fun startRanging(peerId: String, remoteConfig: UwbSessionConfig)
 
     /** Stop ranging with the given peer. */
-    fun stopRanging(peerId: String)
+    suspend fun stopRanging(peerId: String)
 
     /** Register callback for ranging distance updates. */
     fun setRangingCallback(callback: (peerId: String, distance: Double, azimuth: Double?, elevation: Double?) -> Unit)
@@ -50,5 +50,5 @@ expect class MultiplatformUwbManager {
     fun setErrorCallback(callback: (error: String) -> Unit)
 
     /** Clean up resources and unbind services. Call when done using the manager. */
-    fun cleanup()
+    suspend fun cleanup()
 }

--- a/uwbmodule/src/commonMain/kotlin/UwbSessionConfig.kt
+++ b/uwbmodule/src/commonMain/kotlin/UwbSessionConfig.kt
@@ -7,11 +7,9 @@ package com.dustedrob.uwb
  * On iOS: contains the NearbyInteraction discovery token (serialized).
  */
 data class UwbSessionConfig(
+    val scope: Any,
     /** Agreed-upon session identifier. Both peers must use the same value. */
-
-
     val sessionId: Int,
-
     /** UWB channel number (e.g., 9). */
     val channel: Int,
     /** Preamble index for the UWB channel (e.g., 10). */
@@ -129,7 +127,7 @@ data class UwbSessionConfig(
     }
 
     override fun hashCode(): Int {
-        var result :Int = sessionId
+        var result :Int = sessionId!!
         result =  31 * result + channel
         result =  31 * result + preambleIndex
         result =  31 * result + uwbAddress.contentHashCode()
@@ -179,9 +177,10 @@ data class UwbSessionConfig(
             } else {
                 null
             }
-            // Note: sessionId == 0 is a valid value (iOS local configs use it, and the controller
-            // assigns the real id at ranging time), so it must not be treated as "not a config".
+
+            val localScope: Any = 0
             return UwbSessionConfig(
+                scope= localScope,
                 sessionId = sessionId,
                 channel = channel,
                 preambleIndex = preambleIndex,

--- a/uwbmodule/src/iosMain/kotlin/BleManager.kt
+++ b/uwbmodule/src/iosMain/kotlin/BleManager.kt
@@ -60,7 +60,7 @@ actual class BleManager(
     /** Deliver an accessory's raw configuration blob (opaque — wrapped, not parsed as our envelope). */
     private fun deliverAccessoryConfig(peerId: String, raw: ByteArray) {
         NSLog("BleManager: received accessory config from $peerId (${raw.size} bytes)")
-        configExchangedCallback?.invoke(peerId, UwbSessionConfig(0, 0, 0, ByteArray(0), accessoryData = raw))
+        configExchangedCallback?.invoke(peerId, UwbSessionConfig(0, 0, 0, 0, ByteArray(0), accessoryData = raw))
     }
 
     /** Find a characteristic on a discovered service by UUID string (CBUUID normalizes short/long). */

--- a/uwbmodule/src/iosMain/kotlin/MultiplatformUwbManager.ios.kt
+++ b/uwbmodule/src/iosMain/kotlin/MultiplatformUwbManager.ios.kt
@@ -22,13 +22,14 @@ import platform.NearbyInteraction.NINearbyObjectRemovalReason
 import platform.NearbyInteraction.NINearbyPeerConfiguration
 import platform.NearbyInteraction.NISession
 import platform.NearbyInteraction.NISessionDelegateProtocol
+import platform.Security.kSSLSessionConfig_ATSv1
 import platform.darwin.NSObject
 import platform.darwin.dispatch_async
 import platform.darwin.dispatch_get_main_queue
 
 @OptIn(ExperimentalForeignApi::class)
 actual class MultiplatformUwbManager {
-    private var niSession: NISession? = null
+    //private var niSession: NISession? = null
     private var rangingCallback: ((String, Double, Double?, Double?) -> Unit)? = null
     private var errorCallback: ((String) -> Unit)? = null
 
@@ -36,7 +37,7 @@ actual class MultiplatformUwbManager {
     private var sendToPeerCallback: ((String, ByteArray) -> Unit)? = null
 
     /** The accessory peer currently being ranged (single-accessory session; multi-accessory is future). */
-    private var accessoryPeerId: String? = null
+    //private var accessoryPeerId: String? = null
 
     /**
      * NearbyInteraction direction APIs (`horizontalAngle`, `verticalDirectionEstimate`) are iOS 16+.
@@ -48,8 +49,12 @@ actual class MultiplatformUwbManager {
     /** Maps peer ID → the token we received from that peer. */
     private val activePeers = mutableMapOf<String, NIDiscoveryToken>()
 
+    private val activeSessions = mutableMapOf<String, UwbSessionConfig>()
+
+    private val activeDelegates = mutableMapOf<NISession, SessionDelegate>()
+
     /** Our local discovery token, available after session creation. */
-    private var localDiscoveryToken: NIDiscoveryToken? = null
+    //private var localDiscoveryToken: NIDiscoveryToken? = null
 
     /** Strong reference to delegate to prevent GC. */
     private var sessionDelegate: SessionDelegate? = null
@@ -62,24 +67,23 @@ actual class MultiplatformUwbManager {
             errorCallback?.invoke("NearbyInteraction not supported on this device")
             return
         }
+    }
 
-        val session = NISession()
-        niSession = session
+    actual suspend fun getLocalConfig(isAccessory:Boolean): UwbSessionConfig? {
 
+        val session = NISession();
         val delegate = SessionDelegate()
-        sessionDelegate = delegate
+        activeDelegates[session] = delegate
         session.delegate = delegate
 
         // The session's discoveryToken is available immediately after creation
-        localDiscoveryToken = session.discoveryToken
+        val localDiscoveryToken = session.discoveryToken
         if (localDiscoveryToken == null) {
             NSLog("UwbManager: Warning — discoveryToken is null after session creation")
         } else {
             NSLog("UwbManager: Initialized with discovery token")
         }
-    }
 
-    actual fun getLocalConfig(isAccessory:Boolean): UwbSessionConfig? {
         val token = localDiscoveryToken ?: return null
 
         // Serialize the discovery token via NSKeyedArchiver
@@ -102,6 +106,7 @@ actual class MultiplatformUwbManager {
         val tokenBytes = tokenData.toByteArray()
 
         return UwbSessionConfig(
+            scope = session,
             sessionId = 0, // Not used on iOS
             channel = 0,
             preambleIndex = 0,
@@ -110,13 +115,9 @@ actual class MultiplatformUwbManager {
         )
     }
 
-    actual fun startRanging(peerId: String, remoteConfig: UwbSessionConfig) {
-        val session = niSession
-        if (session == null) {
-            errorCallback?.invoke("NI session not initialized. Call initialize() first.")
-            return
-        }
+    actual suspend fun startRanging(peerId: String, remoteConfig: UwbSessionConfig) {
 
+        val sessionConfig = getLocalConfig(remoteConfig.isAccessoryDevice)
         // Accessory ranging: build an accessory configuration from the accessory's data blob. NI then
         // generates shareable configuration data (see didGenerateShareableConfigurationData), which we
         // write back to the accessory over BLE to actually start ranging.
@@ -138,9 +139,10 @@ actual class MultiplatformUwbManager {
                     NSLog("MultiPlatformMgr device DOES NOT support camera assistance")
                 }
             }
-            accessoryPeerId = peerId
+            activeSessions[peerId]= sessionConfig as UwbSessionConfig
+            //accessoryPeerId = peerId
             NSLog("UwbManager: Starting accessory ranging with $peerId")
-            session.runWithConfiguration(config)
+            (sessionConfig.scope as NISession).runWithConfiguration(config)
             return
         }
 
@@ -169,19 +171,20 @@ actual class MultiplatformUwbManager {
         }
 
         activePeers[peerId] = peerToken
-
+        activeSessions[peerId] = sessionConfig as UwbSessionConfig
         // Create a peer configuration with the exchanged token
         val config = NINearbyPeerConfiguration(peerToken)
 
         NSLog("UwbManager: Starting ranging with $peerId")
-        session.runWithConfiguration(config)
+        (sessionConfig.scope as NISession).runWithConfiguration(config)
     }
 
-    actual fun stopRanging(peerId: String) {
+    actual suspend fun stopRanging(peerId: String) {
         activePeers.remove(peerId)
-        if (peerId == accessoryPeerId) accessoryPeerId = null
-        if (activePeers.isEmpty() && accessoryPeerId == null) {
-            niSession?.pause()
+        if (activePeers.isEmpty()) {
+            ((activeSessions[peerId]?.scope) as NISession).pause()
+            activeDelegates.remove((activeSessions[peerId]?.scope) as NISession)
+            activeSessions.remove(peerId)
             NSLog("UwbManager: Paused session (no active peers)")
         }
     }
@@ -198,13 +201,9 @@ actual class MultiplatformUwbManager {
         errorCallback = callback
     }
 
-    actual fun cleanup() {
-        niSession?.invalidate()
-        niSession = null
+    actual suspend fun cleanup() {
         activePeers.clear()
-        accessoryPeerId = null
-        localDiscoveryToken = null
-        sessionDelegate = null
+        activeSessions.clear()
         NSLog("UwbManager: Cleanup completed")
     }
 
@@ -220,9 +219,8 @@ actual class MultiplatformUwbManager {
                         if (!distance.isNaN()) {
                             // Accessory objects aren't in activePeers (keyed by peer tokens), so fall
                             // back to the tracked accessory peer.
-                            val peerId = activePeers.entries
-                                .find { it.value == obj.discoveryToken }?.key
-                                ?: accessoryPeerId ?: "unknown"
+                            val peerId:String = activeSessions.entries
+                                .firstOrNull { it.value.scope  == session }?.key ?: "unknown"
 
                             // Azimuth (`horizontalAngle`) is iOS 16+ and is NaN until camera-assistance
                             // convergence, so only emit it when available and valid. NearbyInteraction
@@ -255,9 +253,9 @@ actual class MultiplatformUwbManager {
             dispatchToMain {
                 didRemoveNearbyObjects.forEach { obj ->
                     if (obj is NINearbyObject) {
-                        val peerId = activePeers.entries
-                            .find { it.value == obj.discoveryToken }?.key
-                        peerId?.let {
+                        val peerId:String = activeSessions.entries
+                            .firstOrNull { it.value.scope  == session }?.key ?: "unknown"
+                        peerId.let {
                             activePeers.remove(it)
                             NSLog("UwbManager: Peer $it removed, reason=$withReason")
                         }
@@ -272,8 +270,8 @@ actual class MultiplatformUwbManager {
                 NSLog("UwbManager: Session invalidated: $msg")
                 errorCallback?.invoke("NI Session error: $msg")
                 activePeers.clear()
-                niSession = null
-                localDiscoveryToken = null
+                activeSessions.clear()
+                activeDelegates.clear()
             }
         }
 
@@ -284,11 +282,9 @@ actual class MultiplatformUwbManager {
         ) {
             // Accessory ranging: NI produced the data the accessory needs to start. Send it back over
             // BLE, prefixed with the configure-and-start message id.
-            val peerId = accessoryPeerId
-            if (peerId == null) {
-                NSLog("UwbManager: shareable config generated but no accessory peer tracked")
-                return
-            }
+            val peerId:String = activeSessions.entries
+                .firstOrNull { it.value.scope  == session }?.key ?: "unknown"
+
             val payload = byteArrayOf(NI_ACCESSORY_CONFIGURE_AND_START) + didGenerateShareableConfigurationData.toByteArray()
             NSLog("UwbManager: sending configure-and-start to $peerId (${payload.size} bytes)")
             sendToPeerCallback?.invoke(peerId, payload)
@@ -333,10 +329,15 @@ actual class MultiplatformUwbManager {
         }
 
         override fun sessionDidStartRunning(session: NISession) {
-            NSLog("UwbManager: Session started running")
+            val peerId:String = activeSessions.entries
+                .firstOrNull { it.value.scope  == session }?.key ?: "unknown"
+            NSLog("UwbManager: Session started running for ${peerId}")
         }
 
         override fun sessionWasSuspended(session: NISession) {
+            val peerId:String = activeSessions.entries
+                .firstOrNull { it.value.scope  == session }?.key ?: "unknown"
+            NSLog("UwbManager: Session suspended for ${peerId}")
             dispatchToMain {
                 errorCallback?.invoke("NI Session was suspended")
             }


### PR DESCRIPTION
add support for accessory multi-session,

works good for android, 
one device is suspended on iOS.. always same, my custom..
Qorvo multi works on both.

tested on iPhone 15 Pro max and 17 Pro max.. so doesn't seem cpu problem.

this exposes the phone-to-phone  ranging protocol as the localConfig UwbSessionConfig( created by Discovery Manager and passed to BleManager) is incorrect, without a scope it has no HW address, each new scope creates a new HW address

pulled localConfig out of initialize as that is once per app, we need once per session
