### PR TITLE
Peer with scan mask

### DIFF
--- a/composeApp/src/commonMain/kotlin/AccessoryProfiles.kt
+++ b/composeApp/src/commonMain/kotlin/AccessoryProfiles.kt
@@ -24,11 +24,22 @@ object QorvoNearbyProfile : UwbProfile {
 /** Nordic UART Service — a common Nearby-Interaction accessory transport. */
 object NordicUartProfile : UwbProfile {
     override val name = "NordicUart"
-
     override val discoveryServiceUuid = "6E400001-B5A3-F393-E0A9-E50E24DCCA9E"
     override val writeToUuid = "6E400002-B5A3-F393-E0A9-E50E24DCCA9E"    // RX (host -> accessory)
     override val notifyFromUuid = "6E400003-B5A3-F393-E0A9-E50E24DCCA9E" // TX (accessory -> host, notify)
     override val readFromUuid: String? = null
+
+    override val exchange = ExchangeProtocol.AccessoryNotify
+}
+object CNCustomProfile : UwbProfile {
+    override val name = "CNCustom"
+
+    override val advertisedUuid = "11000000-27B9-42F0-82AA-2E951747BBF9"
+    override val advertisedUUIDMask = "########-27B9-42F0-82AA-2E951747BBF9"
+    override val discoveryServiceUuid = "2E938FD0-6A61-11ED-A1EB-0242AC120002"
+    override val readFromUuid = "2E93941C-6A61-11ED-A1EB-0242AC120002"   // readable char (props 0x2)
+    override val writeToUuid = "2E93998A-6A61-11ED-A1EB-0242AC120002"    // control / rx char (props 0xC)
+    override val notifyFromUuid = "2E939AF2-6A61-11ED-A1EB-0242AC120002" // accessory tx / notify (props 0x10)
 
     override val exchange = ExchangeProtocol.AccessoryNotify
 }

--- a/composeApp/src/commonMain/kotlin/UwbDiscoveryViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/UwbDiscoveryViewModel.kt
@@ -32,7 +32,7 @@ class UwbDiscoveryViewModel(
         // Phone-to-phone over LOCAL_PROFILE, plus the Qorvo accessory (app-owned profile).
         managerFactory.createBleManager(
             BleDiscoveryConfig(
-                profiles = listOf(LOCAL_PROFILE, QorvoNearbyProfile),
+                profiles = listOf(LOCAL_PROFILE, QorvoNearbyProfile, CNCustomProfile),
                 // Opt in to the Android accessory protocol (the bespoke write-init / notify-back
                 // exchange). It is OFF by default in the library because on Android it only works
                 // against compatible custom accessory firmware (see the "Accessory ranging" section in

--- a/uwbmodule/src/androidMain/kotlin/BleManager.kt
+++ b/uwbmodule/src/androidMain/kotlin/BleManager.kt
@@ -126,23 +126,51 @@ actual class BleManager(
         override fun onScanResult(callbackType: Int, result: ScanResult) {
             val device = result.device
             val deviceAddress = device.address
-            val deviceName = if (hasConnectPermission()) device.name ?: "Unknown Device" else "Unknown Device"
+            val deviceName =
+                if (hasConnectPermission()) device.name ?: "Unknown Device" else "Unknown Device"
             if (discoveredDevices[deviceAddress] != null) return
 
             var profile: UwbProfile? = null
-            result.scanRecord?.serviceUuids?.forEach { uuid ->
-                config.activeProfiles.forEach { p ->
-                    // Android normalizes 16-bit advertisements to the full base UUID, so a plain
-                    // case-insensitive full-string compare matches both short and long forms.
-                    if (profile == null && p.advertisedUuid.equals(uuid.toString(), ignoreCase = true)) {
-                        profile = p
+            // loop thru the service IDs
+            if(result.scanRecord != null &&  result.scanRecord?.serviceUuids !=null) {
+                for (uuid in result.scanRecord?.serviceUuids!!) {
+                    // look in each profile
+                    for (p in config.activeProfiles) {
+                        // if there is a UUID mask specified
+                        if (p.advertisedUUIDMask != "*") {
+                            Log.d(
+                                TAG,
+                                "Have UUID filter for profile ${p.name} = ${p.advertisedUUIDMask}"
+                            )
+                            Log.d(TAG, "checking serviceid ${uuid.toString()}")
+                            if (createUUIDFilter(p.advertisedUUIDMask).matches(uuid.toString())) {
+                                Log.d(TAG, " UUID matches filter = ${p.advertisedUUIDMask}")
+                                // if good
+                                profile = p
+                                break;
+                            }
+                        }
+                        // Android normalizes 16-bit advertisements to the full base UUID, so a plain
+                        // case-insensitive full-string compare matches both short and long forms.
+                        else if (p.advertisedUuid.equals(uuid.toString(), ignoreCase = true)) {
+                            profile = p
+                            break;
+                        }
                     }
+                    if (profile == null)
+                        break
                 }
             }
-            discoveredDevices[deviceAddress] = AccessoryDevice(device, profile)
-            uwbManager.createConnectionConfig(deviceAddress, profile?.exchange == ExchangeProtocol.AccessoryNotify)
-            Log.d(TAG, "Found device: $deviceName ($deviceAddress) profile=${profile?.name}")
-            deviceDiscoveredCallback?.invoke(deviceAddress, deviceName)
+            // if we found a match
+            if(profile != null) {
+                discoveredDevices[deviceAddress] = AccessoryDevice(device, profile)
+                uwbManager.createConnectionConfig(
+                    deviceAddress,
+                    profile?.exchange == ExchangeProtocol.AccessoryNotify
+                )
+                Log.d(TAG, "Found device: $deviceName ($deviceAddress) profile=${profile?.name}")
+                deviceDiscoveredCallback?.invoke(deviceAddress, deviceName)
+            }
         }
 
         override fun onScanFailed(errorCode: Int) {
@@ -294,13 +322,22 @@ actual class BleManager(
                 Log.w(TAG, "Accessory profiles ignored: set BleDiscoveryConfig.enableAndroidAccessoryProtocol to use them")
             }
             val filters: MutableList<ScanFilter> = mutableListOf()
-            config.activeProfiles.forEach { profile ->
-                val scanFilter = ScanFilter.Builder()
-                    .setServiceUuid(ParcelUuid(UUID.fromString(profile.advertisedUuid.uppercase())))
-                    .build()
-                filters.add(scanFilter)
+            val hasMask: Boolean= config.activeProfiles.any{
+                it.advertisedUUIDMask!="*"
+            }
+            if( !hasMask) {
+                config.activeProfiles.forEach { profile ->
+                    val scanFilter = ScanFilter.Builder()
+                        .setServiceUuid(ParcelUuid(UUID.fromString(profile.advertisedUuid.uppercase())))
+                        .build()
+                    filters.add(scanFilter)
+                }
+
             }
             scanner.startScan(filters, scanSettings, scanCallback)
+            if(hasMask)
+                setTimeout(ScanTime, { stopScanning() })
+
             Log.d(TAG, "BLE scanning started")
         } catch (e: Exception) {
             Log.e(TAG, "Error starting BLE scan: ${e.message}")

--- a/uwbmodule/src/androidMain/kotlin/MultiplatformUwbManager.android.kt
+++ b/uwbmodule/src/androidMain/kotlin/MultiplatformUwbManager.android.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import androidx.core.uwb.RangingParameters
 import androidx.core.uwb.RangingResult
 import androidx.core.uwb.UwbAddress
+import androidx.core.uwb.UwbClientSessionScope
 import androidx.core.uwb.UwbComplexChannel
 import androidx.core.uwb.UwbControleeSessionScope
 import androidx.core.uwb.UwbControllerSessionScope
@@ -16,30 +17,44 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import java.security.SecureRandom
+import java.util.concurrent.ConcurrentHashMap
 
 actual class MultiplatformUwbManager(private val androidUwbManager: UwbManager? = null) {
     private val TAG = "UwbManager"
 
     private var rangingCallback: ((String, Double, Double?, Double?) -> Unit)? = null
-    private var errorCallback: ((String) -> Unit)? = null
+    private var errorCallback: ((String?, String) -> Unit)? = null
 
     /**
-     * Stored for `expect` parity; unused on Android. androidx.core.uwb takes all ranging parameters
-     * up front and generates nothing post-`prepareSession`, so there is no data to send back to a peer
-     * (unlike iOS, where NI produces shareable configuration data after the session runs).
+     * Stored for `expect` parity; on Android only the accessory path uses it, to push our config to
+     * the accessory before the session starts (androidx.core.uwb generates nothing post-`prepareSession`,
+     * unlike iOS where NI produces shareable configuration data after the session runs).
      */
     private var sendToPeerCallback: ((String, ByteArray) -> Unit)? = null
     private val coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
 
     /** Active ranging coroutine jobs, keyed by peer ID. Cancel to stop ranging. */
-    private val activeJobs = mutableMapOf<String, Job>()
+    private val activeJobs = ConcurrentHashMap<String, Job>()
 
-    /** Local config we created per peer (our address, session id, key). */
-    private val connectionConfigs = mutableMapOf<String, UwbSessionConfig>()
+    /** Local config we created per peer (our addresses, session key). */
+    private val connectionConfigs = ConcurrentHashMap<String, UwbSessionConfig>()
 
-    private var controllerScope: UwbControllerSessionScope? = null
-    private var controleeScope: UwbControleeSessionScope? = null
+    /**
+     * One pair of session scopes per peer. androidx.core.uwb scopes are single-use: a scope's
+     * `prepareSession` can only be collected once, and its local address is retired when that session
+     * ends. Sharing one controller and one controlee scope across peers therefore caps us at one
+     * session per role and poisons the scope after any stop. Both roles are allocated up front because
+     * the peer needs both of our addresses before either side knows who will be controller; the scope
+     * we don't end up using is just dropped.
+     */
+    private class PeerScopes(
+        val controller: UwbControllerSessionScope,
+        val controlee: UwbControleeSessionScope?,
+    )
+
+    private val peerScopes = ConcurrentHashMap<String, PeerScopes>()
 
     /** Static-STS key, generated once and reused so it is stable across a peer's BLE identities. */
     private var localSessionKey: ByteArray? = null
@@ -55,23 +70,19 @@ actual class MultiplatformUwbManager(private val androidUwbManager: UwbManager? 
     }
     actual suspend fun initialize() {
         if (androidUwbManager == null) {
-            errorCallback?.invoke("UWB not supported on this device")
+            errorCallback?.invoke(null, "UWB not supported on this device")
             return
         }
         try {
             Log.d(TAG,"uwbmanager init")
-            controleeScope = androidUwbManager.controleeSessionScope()// androidUwbManager.controleeSessionScope()
-            //sessionScope = scope
-            // need this for ranging wit accessory, can't create later
-            controllerScope = androidUwbManager.controllerSessionScope()
-
+            // Scopes are now minted per peer in createConnectionConfig; here we only sanity-check the
+            // radio. The probe scope is discarded (its address is never advertised).
             val capabilities = androidUwbManager.controllerSessionScope().rangingCapabilities
             if (!capabilities.isDistanceSupported) {
-                errorCallback?.invoke("UWB distance ranging not supported")
+                errorCallback?.invoke(null, "UWB distance ranging not supported")
             }
-            //Log.d(TAG, "UWB initialized. Local address: ${scope.localAddress}")
         } catch (e: Exception) {
-            errorCallback?.invoke("Failed to initialize UWB: ${e.message}")
+            errorCallback?.invoke(null, "Failed to initialize UWB: ${e.message}")
         }
     }
 
@@ -79,60 +90,64 @@ actual class MultiplatformUwbManager(private val androidUwbManager: UwbManager? 
         // One config per peer: a repeat discovery must not regenerate the session key mid-exchange,
         // or the copy we already advertised over BLE would no longer match what we range with.
         connectionConfigs[peerId]?.let { return it }
-        val localScope = if(isAccessory){
-            controllerScope
-        } else {
-            controleeScope
+        val manager = androidUwbManager ?: return null
+
+        // Fresh scopes for this peer (see PeerScopes). Scope creation is a short GMS round trip
+        // (suspend); this is called from BLE binder-thread callbacks, one of which (the GATT read)
+        // has to answer in-line with the config, so block here rather than restructure the BLE
+        // layer around a callback. It can still throw when the radio is off; report and bail rather
+        // than crash the callback.
+        val scopes = try {
+            runBlocking {
+                PeerScopes(
+                    controller = manager.controllerSessionScope(),
+                    controlee = if (isAccessory) null else manager.controleeSessionScope(),
+                )
+            }
+        } catch (e: Exception) {
+            errorCallback?.invoke(peerId, "Failed to create UWB session scope: ${e.message}")
+            return null
         }
-        Log.d(TAG, "localScope = $localScope")
-        // get the local device uwb HW address
-        val localAddress = localScope?.localAddress?.address
+        peerScopes[peerId] = scopes
 
-        // Generate a session ID from our address for deterministic agreement.
-        // During config exchange, the initiator's sessionId is used by convention
-        // (the peer with the lexicographically smaller address initiates).
+        // The address we advertise as "ours": the controlee address for P2P (the peer's controller
+        // ranges against it), the controller address for accessories (the phone is always controller).
+        val localAddress = (scopes.controlee ?: scopes.controller).localAddress.address
 
-        val sessionId:Int? = localAddress?.fold(0) { acc, b -> acc * 31 + (b.toInt() and 0xFF) }
+        // For P2P the real session id is derived per pair in startRanging once roles are known; this
+        // one is only used by accessories, which adopt our config verbatim.
+        val sessionId: Int = UwbSessionConfig.sessionIdFor(scopes.controller.localAddress.address, localAddress)
 
         // Generate the static-STS key once per manager and reuse it. A phone seen under several
         // randomized BLE addresses would otherwise hand out a different key per identity, and the one
         // the peer keeps might not match the one we range with. One cached key keeps them consistent.
+        // It also doubles as our stable identity for the peer's duplicate-BLE-identity dedup.
         val key = localSessionKey ?: ByteArray(SESSION_KEY_SIZE)
             .also { SecureRandom().nextBytes(it) }
             .also { localSessionKey = it }
 
-        Log.d(TAG, "phone address is ${localAddress?.toHexString()}")
+        Log.d(TAG, "phone address for $peerId is ${localAddress.toHexString()}")
 
         // For peer-to-peer, also advertise our controller-scope address so that after role election
         // the controller can range against the peer's controlee address and vice versa. Accessories
         // don't need it (the phone is always controller and the accessory adopts our params).
-        val controllerAddr = if (isAccessory) null else controllerScope?.localAddress?.address
+        val controllerAddr = if (isAccessory) null else scopes.controller.localAddress.address
 
-        val connectionConfig: UwbSessionConfig? = if(sessionId !=null ) {
-            UwbSessionConfig(
-                timestamp = System.currentTimeMillis(),
-                sessionId = sessionId,
-                channel = DEFAULT_CHANNEL,
-                preambleIndex = DEFAULT_PREAMBLE_INDEX,
-                uwbAddress = localAddress,
-                discoveryToken = null,
-                sessionKey = key,
-                controllerAddress = controllerAddr,
-            )
-        } else {
-            null
-        }
-        connectionConfigs[peerId]= connectionConfig as UwbSessionConfig
+        val connectionConfig = UwbSessionConfig(
+            timestamp = System.currentTimeMillis(),
+            sessionId = sessionId,
+            channel = DEFAULT_CHANNEL,
+            preambleIndex = DEFAULT_PREAMBLE_INDEX,
+            uwbAddress = localAddress,
+            discoveryToken = null,
+            sessionKey = key,
+            controllerAddress = controllerAddr,
+        )
+        connectionConfigs[peerId] = connectionConfig
         return connectionConfig
     }
 
-    actual fun getConnectionConfig(peerId:String):UwbSessionConfig? {
-        return if(connectionConfigs[peerId] != null){
-             connectionConfigs[peerId]
-        } else {
-             null
-        }
-    }
+    actual fun getConnectionConfig(peerId:String):UwbSessionConfig? = connectionConfigs[peerId]
 
     actual suspend fun startRanging(peerId: String, remoteConfig: UwbSessionConfig) {
 
@@ -140,6 +155,7 @@ actual class MultiplatformUwbManager(private val androidUwbManager: UwbManager? 
         activeJobs[peerId]?.cancel()
 
         val localConfig = getConnectionConfig(peerId)
+        val scopes = peerScopes[peerId]
 
         val job = coroutineScope.launch {
             try {
@@ -150,9 +166,14 @@ actual class MultiplatformUwbManager(private val androidUwbManager: UwbManager? 
                 val amController = isAccessory || localConfig == null ||
                         localConfig.ownsSessionOver(remoteConfig)
 
-                // Use the pre-created scope for our role, so we range with an address the peer already
-                // received (never mint a new scope/address after the exchange).
-                val scope = if (amController) controllerScope else controleeScope
+                // Use this peer's pre-created scope for our role, so we range with an address the
+                // peer already received (never mint a new scope/address after the exchange).
+                val scope: UwbClientSessionScope? = if (amController) scopes?.controller else scopes?.controlee
+                if (scope == null) {
+                    errorCallback?.invoke(peerId, "No UWB session scope for $peerId; createConnectionConfig must run first")
+                    releasePeer(peerId)
+                    return@launch
+                }
 
                 // Range against the peer's opposite-role address: the controller talks to the peer's
                 // controlee address ([uwbAddress]); the controlee talks to the peer's controller
@@ -166,12 +187,20 @@ actual class MultiplatformUwbManager(private val androidUwbManager: UwbManager? 
                 // Session parameters come from the controller (owner); the controlee adopts them.
                 val paramsConfig = if (amController) (localConfig ?: remoteConfig) else remoteConfig
 
+                // One session per peer needs one id per pair, agreed by both ends without another
+                // round trip. Accessories adopt the id we already sent them.
+                val sessionId = when {
+                    isAccessory -> paramsConfig.sessionId
+                    amController -> UwbSessionConfig.sessionIdFor(scope.localAddress.address, peerAddressBytes)
+                    else -> UwbSessionConfig.sessionIdFor(peerAddressBytes, scope.localAddress.address)
+                }
+
                 val peerDevice = UwbDevice(UwbAddress(peerAddressBytes))
                 Log.d(TAG, "ranging peer device address is ${peerAddressBytes.toHexString()} (amController=$amController)")
 
                 val rangingParameters: RangingParameters = RangingParameters(
                     uwbConfigType = RangingParameters.CONFIG_UNICAST_DS_TWR,
-                    sessionId = paramsConfig.sessionId,
+                    sessionId = sessionId,
                     subSessionId = 0,
                     sessionKeyInfo = paramsConfig.sessionKey,
                     subSessionKeyInfo = null,
@@ -185,7 +214,7 @@ actual class MultiplatformUwbManager(private val androidUwbManager: UwbManager? 
 
                 Log.d(
                     TAG,
-                    "Starting ranging with $peerId — session=${paramsConfig.sessionId.toHexString()} ch=${paramsConfig.channel} pai=${paramsConfig.preambleIndex}  peer=${peerAddressBytes.toHexString()} amController=$amController"
+                    "Starting ranging with $peerId — session=${sessionId.toHexString()} ch=${paramsConfig.channel} pai=${paramsConfig.preambleIndex}  local=${scope.localAddress.address.toHexString()} peer=${peerAddressBytes.toHexString()} amController=$amController"
                 )
                 // if this is an accessory, send the config it should use now, as we have done all the pre-checking
                 if(remoteConfig.isAccessoryDevice) {
@@ -194,20 +223,15 @@ actual class MultiplatformUwbManager(private val androidUwbManager: UwbManager? 
                     message?.let { sendToPeerCallback?.invoke(peerId, it) }
                 }
 
-                if (scope == null) {
-                    errorCallback?.invoke("No UWB session scope for $peerId; initialize() must run first")
-                    activeJobs.remove(peerId)
-                    return@launch
-                }
                 scope.prepareSession(rangingParameters)
                     .catch { exception ->
-                        errorCallback?.invoke("Ranging failed for $peerId: ${exception.message}")
+                        errorCallback?.invoke(peerId, "Ranging failed for $peerId: ${exception.message}")
+                        releasePeer(peerId)
                     }
                     .collect { result ->
-                        Log.d(TAG, "in collect")
                         when (result) {
                             is RangingResult.RangingResultPosition -> {
-                                Log.d(TAG,"Ranging position report")
+                                Log.d(TAG,"Ranging position report for $peerId")
                                 val distance = result.position.distance?.value
                                 if (distance != null) {
                                     rangingCallback?.invoke(
@@ -220,13 +244,15 @@ actual class MultiplatformUwbManager(private val androidUwbManager: UwbManager? 
                             }
 
                             is RangingResult.RangingResultInitialized ->{
-                                Log.d(TAG,"Ranging init")
+                                Log.d(TAG,"Ranging init for $peerId")
                             }
 
                             is RangingResult.RangingResultPeerDisconnected -> {
                                 Log.d(TAG,"peer disconnected ${peerId}")
-                                errorCallback?.invoke("Peer $peerId disconnected")
-                                activeJobs.remove(peerId)
+                                errorCallback?.invoke(peerId, "Peer $peerId disconnected")
+                                // The scope's address is retired with the session; a re-discovery
+                                // must mint a fresh scope and config.
+                                releasePeer(peerId)
                             }
 
                             else ->{
@@ -236,9 +262,9 @@ actual class MultiplatformUwbManager(private val androidUwbManager: UwbManager? 
                     }
                 } catch (e: Exception) {
                     Log.d(TAG,"Ranging startup failed, ${e.message}")
-                    errorCallback?.invoke("Failed to start ranging with $peerId: ${e.message}")
+                    errorCallback?.invoke(peerId, "Failed to start ranging with $peerId: ${e.message}")
+                    releasePeer(peerId)
                 }
-                Log.d(TAG,"Ranging active (maybe)")
             }
             Log.d(TAG,"Ranging process starting for peer ${peerId}")
             activeJobs[peerId] = job
@@ -249,6 +275,19 @@ actual class MultiplatformUwbManager(private val androidUwbManager: UwbManager? 
             job.cancel()
             Log.d(TAG, "Stopped ranging with $peerId")
         }
+        peerScopes.remove(peerId)
+        connectionConfigs.remove(peerId)
+    }
+
+    /**
+     * Forget a peer whose session has ended or failed. Its scope (and address) is spent, so the next
+     * discovery of that peer starts over with a fresh scope and config. The job is left to finish
+     * on its own (this is called from inside it).
+     */
+    private fun releasePeer(peerId: String) {
+        activeJobs.remove(peerId)
+        peerScopes.remove(peerId)
+        connectionConfigs.remove(peerId)
     }
 
     actual fun setRangingCallback(callback: (peerId: String, distance: Double, azimuth: Double?, elevation: Double?) -> Unit) {
@@ -259,7 +298,7 @@ actual class MultiplatformUwbManager(private val androidUwbManager: UwbManager? 
         sendToPeerCallback = callback
     }
 
-    actual fun setErrorCallback(callback: (error: String) -> Unit) {
+    actual fun setErrorCallback(callback: (peerId: String?, error: String) -> Unit) {
         errorCallback = callback
     }
 
@@ -267,9 +306,9 @@ actual class MultiplatformUwbManager(private val androidUwbManager: UwbManager? 
     actual suspend fun cleanup() {
         activeJobs.values.forEach { it.cancel() }
         activeJobs.clear()
+        peerScopes.clear()
         connectionConfigs.clear()
         localSessionKey = null
         coroutineScope.cancel()
     }
 }
-

--- a/uwbmodule/src/commonMain/kotlin/BleManager.kt
+++ b/uwbmodule/src/commonMain/kotlin/BleManager.kt
@@ -1,9 +1,20 @@
-package com.dustedrob.uwb
+
+@file:JvmName("TimeoutHandler")package com.dustedrob.uwb
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlin.jvm.JvmName
+import kotlin.time.Duration.Companion.milliseconds
 
 /**
  * Platform BLE manager handling device discovery via scanning/advertising
  * and UWB session configuration exchange via GATT.
  */
+
 expect class BleManager {
 
     /** Start scanning for nearby UWB-capable devices. */
@@ -37,7 +48,7 @@ expect class BleManager {
      * Reads the peer's config and writes our own.
      * Result delivered via [setConfigExchangedCallback].
      */
-    fun connectAndExchangeConfig(peerId: String, connectionConfig:UwbSessionConfig)
+    fun connectAndExchangeConfig(peerId: String, connectionConfig: UwbSessionConfig)
 
     /**
      * Register callback invoked when a config exchange completes (on either side).
@@ -56,3 +67,31 @@ expect class BleManager {
     /** Clean up BLE resources. Call when done using the manager. */
     fun cleanup()
 }
+    val BleManager.ScanTime: Long
+        get() = 5000
+
+fun BleManager.setTimeout(delayMillis: Long, block: () -> Unit): Job {
+        return CoroutineScope(Dispatchers.Main + SupervisorJob()).launch {
+            delay(delayMillis.milliseconds)
+            block()
+        }
+    }
+
+
+    fun BleManager.createUUIDFilter(patternMask: String): Regex {
+
+        val cleanedMask = patternMask// .replace("-", "").trim()
+        val regexPattern = buildString {
+            append("^")
+            for (char in cleanedMask) {
+                when (char) {
+                    '.' -> append("[0-9a-fA-F]")  // Any valid hex character
+                    '#' -> append("[0-9]") // Any decimal digit (0-9)
+                    else -> append(char.toString()) // Strict character literal match
+                }
+            }
+            append("$")
+
+        }
+        return Regex(regexPattern, RegexOption.IGNORE_CASE)
+    }

--- a/uwbmodule/src/commonMain/kotlin/DeviceDiscoveryManager.kt
+++ b/uwbmodule/src/commonMain/kotlin/DeviceDiscoveryManager.kt
@@ -77,21 +77,35 @@ class DeviceDiscoveryManager(
     private val accessoryPeers = mutableSetOf<String>()
 
     /**
-     * Maps a peer's stable UWB address (hex) to the peerId currently ranging with it.
+     * Maps a peer's stable identity key (hex) to the peerId currently ranging with it.
      *
      * On Android a single phone appears under several randomized BLE addresses because it both scans
      * and runs a GATT server, so the same physical device arrives under different peerIds. The UWB
-     * address inside the exchanged config is the stable identity, so we key on it and let the newest
-     * connection win — a fresh peerId for a known UWB address supersedes the stale one, keeping one
-     * device entry and one ranging session. Unused on iOS, where the CoreBluetooth UUID is already
-     * stable and the config carries no UWB address.
+     * address is no longer stable across those identities (each peer gets its own session scope, so
+     * a phone hands each of our BLE identities a different address), but the static-STS session key
+     * is generated once per manager and shipped in every config, so it identifies the device. Unused
+     * on iOS, where the CoreBluetooth UUID is already stable and the config carries no key.
      */
-    private val uwbKeyToPeer = mutableMapOf<String, String>()
+    private val identityKeyToPeer = mutableMapOf<String, String>()
 
     companion object {
         /** Devices not seen within this window are considered stale and removed. */
         private const val STALE_THRESHOLD_MS = 10_000L
         private const val CLEANUP_INTERVAL_MS = 5_000L
+
+        /**
+         * Stable identity of the device behind a config, or null when the platform gives none (iOS).
+         *
+         * Phones: the session key (see [identityKeyToPeer]). Accessories: their UWB address, which is
+         * a fixed hardware address; the "remote" config for an accessory is our own config with the
+         * accessory's address patched in, so its key would be ours and every accessory would collide.
+         */
+        internal fun identityKeyFor(remoteConfig: UwbSessionConfig): String? = when {
+            remoteConfig.isAccessoryDevice ->
+                remoteConfig.uwbAddress.takeIf { it.isNotEmpty() }?.let { "acc:" + it.toHexString() }
+            else ->
+                remoteConfig.sessionKey?.takeIf { it.isNotEmpty() }?.let { "key:" + it.toHexString() }
+        }
     }
 
     init {
@@ -114,8 +128,11 @@ class DeviceDiscoveryManager(
             bleManager.sendToPeer(peerId, data)
         }
 
-        multiplatformUwbManager.setErrorCallback { error ->
-            emitEvent(EventType.Error, "", error)
+        multiplatformUwbManager.setErrorCallback { peerId, error ->
+            emitEvent(EventType.Error, peerId ?: "", error)
+            // A per-peer failure only takes that peer out of Ranging, so stale cleanup can drop it
+            // and a re-discovery can start over, while the other sessions carry on.
+            if (peerId != null) scope.launch { onRangingError(peerId, error) }
         }
     }
 
@@ -176,7 +193,7 @@ class DeviceDiscoveryManager(
         exchangedPeers.clear()
         pendingExchanges.clear()
         accessoryPeers.clear()
-        uwbKeyToPeer.clear()
+        identityKeyToPeer.clear()
     }
 
     /**
@@ -200,10 +217,19 @@ class DeviceDiscoveryManager(
             stale.forEach { device ->
                 pendingExchanges.remove(device.id)
                 exchangedPeers.remove(device.id)
+                identityKeyToPeer.entries.removeAll { it.value == device.id }
                 emitEvent(EventType.Error, device.id, "Device stale, removed: ${device.name}")
             }
             _nearbyDevices.value = active
         }
+    }
+
+    /** A ranging session for one peer failed or ended; mark just that device so it can age out. */
+    internal suspend fun onRangingError(peerId: String, error: String) = mutex.withLock {
+        val devices = _nearbyDevices.value
+        val idx = devices.indexOfFirst { it.id == peerId }
+        if (idx == -1 || devices[idx].state != DeviceState.Ranging) return@withLock
+        updateDeviceStateLocked(peerId, DeviceState.Error, error)
     }
 
     private fun emitEvent(type: EventType, peerId: String, message: String) {
@@ -248,31 +274,34 @@ class DeviceDiscoveryManager(
      * Called when BLE GATT config exchange completes with a peer.
      * Starts UWB ranging with the exchanged config.
      */
-    internal suspend fun onConfigExchanged(peerId: String, remoteConfig: UwbSessionConfig) = mutex.withLock {
+    internal suspend fun onConfigExchanged(peerId: String, remoteConfig: UwbSessionConfig) {
+        var duplicateOf: String? = null
+        val shouldStart = mutex.withLock {
             // Guard against duplicate callbacks (both GATT client read and server write fire this)
-            if (peerId in exchangedPeers) return
+            if (peerId in exchangedPeers) return@withLock false
             pendingExchanges.remove(peerId)
             exchangedPeers.add(peerId)
             if (remoteConfig.isAccessoryDevice || remoteConfig.accessoryData!=null) accessoryPeers.add(peerId)
 
             // Collapse duplicate BLE identities of the same physical device. A phone both scans and
             // serves under randomized BLE addresses, so the same device arrives under several peerIds;
-            // the UWB address in the exchanged config is the stable identity. If we're already ranging
-            // that UWB address, keep the first session and ignore the duplicate rather than tearing the
-            // live one down (which churned the session and cancelled its coroutine). Skipped on iOS
-            // (empty uwbAddress), where the peerId is already stable.
-            val uwbKey = remoteConfig.uwbAddress.takeIf { it.isNotEmpty() }?.toHexString()
-            if (uwbKey != null) {
-                val prevPeerId = uwbKeyToPeer[uwbKey]
+            // the session key in the exchanged config is the stable identity (see identityKeyToPeer).
+            // If we're already ranging that device, keep the first session and ignore the duplicate
+            // rather than tearing the live one down (which churned the session and cancelled its
+            // coroutine). Skipped on iOS (no key), where the peerId is already stable.
+            val identityKey = identityKeyFor(remoteConfig)
+            if (identityKey != null) {
+                val prevPeerId = identityKeyToPeer[identityKey]
                 if (prevPeerId != null && prevPeerId != peerId) {
                     // Already ranging this device under another BLE identity. Keep the live session and
                     // drop this identity's placeholder entry so the UI shows one device, not two.
                     // peerId stays in exchangedPeers so we don't re-exchange with the duplicate.
                     _nearbyDevices.value = _nearbyDevices.value.filterNot { it.id == peerId }
-                    emitEvent(EventType.DeviceDiscovered, peerId, "Ignored duplicate identity of $prevPeerId (UWB $uwbKey)")
-                    return
+                    emitEvent(EventType.DeviceDiscovered, peerId, "Ignored duplicate identity of $prevPeerId (key $identityKey)")
+                    duplicateOf = prevPeerId
+                    return@withLock false
                 }
-                uwbKeyToPeer[uwbKey] = peerId
+                identityKeyToPeer[identityKey] = peerId
             }
 
             emitEvent(
@@ -302,11 +331,17 @@ class DeviceDiscoveryManager(
             _nearbyDevices.value = existingDevices
 
             emitEvent(EventType.RangingStarted, peerId, "UWB ranging started")
-        
+            true
+        }
 
-        // Start UWB ranging outside the lock (startRanging may take time)
-        multiplatformUwbManager.startRanging(peerId, remoteConfig)
+        // Start UWB ranging outside the lock: with several peers, one session start must not hold up
+        // the callbacks of the others.
+        if (shouldStart) multiplatformUwbManager.startRanging(peerId, remoteConfig)
+        // The duplicate identity never ranges, so hand back the session resources (on Android the
+        // per-peer scopes and their addresses) that were minted for it at discovery.
+        if (duplicateOf != null) multiplatformUwbManager.stopRanging(peerId)
     }
+
 
     /** Called when UWB ranging data is received. */
     internal suspend fun onRangingResult(peerId: String, distance: Double, azimuth: Double?, elevation: Double?) = mutex.withLock {

--- a/uwbmodule/src/commonMain/kotlin/MultiplatformUwbManager.kt
+++ b/uwbmodule/src/commonMain/kotlin/MultiplatformUwbManager.kt
@@ -47,8 +47,12 @@ expect class MultiplatformUwbManager {
      */
     fun setSendToPeerCallback(callback: (peerId: String, data: ByteArray) -> Unit)
 
-    /** Register callback for errors. */
-    fun setErrorCallback(callback: (error: String) -> Unit)
+    /**
+     * Register callback for errors. [peerId] names the session the error belongs to, or is null for
+     * device-wide failures (UWB unsupported, initialization), so the orchestrator can mark one peer
+     * as failed instead of treating every error as global.
+     */
+    fun setErrorCallback(callback: (peerId: String?, error: String) -> Unit)
 
     /** Clean up resources and unbind services. Call when done using the manager. */
     suspend fun cleanup()

--- a/uwbmodule/src/commonMain/kotlin/UwbProfile.kt
+++ b/uwbmodule/src/commonMain/kotlin/UwbProfile.kt
@@ -32,6 +32,7 @@ interface UwbProfile {
      */
     val advertisedUuid: String get() = discoveryServiceUuid
 
+    val advertisedUUIDMask: String get() = "*"
     /**
      * Characteristic the client reads to obtain the peer's config (the peer's "tx").
      * Used by [ExchangeProtocol.ReadWrite]; null for accessory profiles.

--- a/uwbmodule/src/commonMain/kotlin/UwbSessionConfig.kt
+++ b/uwbmodule/src/commonMain/kotlin/UwbSessionConfig.kt
@@ -203,6 +203,23 @@ data class UwbSessionConfig(
     companion object {
         private const val PROTOCOL_VERSION: Byte = 1
 
+        /**
+         * Session id for one controller/controlee pair.
+         *
+         * With one session per peer, the id has to be unique per pair on this device and identical on
+         * both ends. Both ends know both addresses after the config exchange (the controller its own
+         * controller address and the peer's [uwbAddress]; the controlee the peer's [controllerAddress]
+         * and its own [uwbAddress]), so folding the pair in a fixed order gives the same id on each
+         * side without another round trip. Never 0, which the stack treats as "derive it yourself".
+         */
+        fun sessionIdFor(controllerAddress: ByteArray, controleeAddress: ByteArray): Int {
+            var h = 17
+            for (b in controllerAddress) h = h * 31 + (b.toInt() and 0xFF)
+            h = h * 31 + 0x5A
+            for (b in controleeAddress) h = h * 31 + (b.toInt() and 0xFF)
+            return if (h == 0) 1 else h
+        }
+
         fun fromByteArray(
             bytes: ByteArray,
             accessoryDevice: Boolean = false

--- a/uwbmodule/src/commonTest/kotlin/com/dustedrob/uwb/DeviceDiscoveryManagerTest.kt
+++ b/uwbmodule/src/commonTest/kotlin/com/dustedrob/uwb/DeviceDiscoveryManagerTest.kt
@@ -107,34 +107,40 @@ class DeviceDiscoveryManagerTest {
         assertTrue("d1" !in pendingExchanges)
     }
 
-    // -- Peer-identity dedup by UWB address (mirrors onConfigExchanged's newest-wins logic) --
+    // -- Peer-identity dedup (identityKeyFor + the keep-first rule in onConfigExchanged) --
+
+    private val keyA = byteArrayOf(1, 2, 3, 4, 5, 6, 7, 8)
+    private val keyB = byteArrayOf(8, 7, 6, 5, 4, 3, 2, 1)
+
+    private fun phoneConfig(addr: ByteArray, key: ByteArray) =
+        UwbSessionConfig(1, 9, 11, addr, sessionKey = key)
 
     @Test
-    fun sameUwbAddressUnderTwoBleIdsCollapsesToOne() {
-        // A phone that both scans and serves shows up under two randomized BLE ids but reports the
-        // same UWB address; the first live session is kept and the later duplicate is ignored (no
-        // teardown of the running session).
-        val uwbKeyToPeer = mutableMapOf<String, String>()
+    fun samePhoneUnderTwoBleIdsCollapsesToOne() {
+        // A phone that both scans and serves shows up under two randomized BLE ids. With one session
+        // scope per peer it also hands each of our identities a different UWB address, so the address
+        // can't be the identity any more; the session key (one per device) is. First one is kept, the
+        // later duplicate is ignored (no teardown of the running session).
+        val identityKeyToPeer = mutableMapOf<String, String>()
         val devices = mutableListOf(
             NearbyDevice("58:CD:3D:CF:63:7F", "UWB Device"),
             NearbyDevice("43:E3:E1:1B:D4:97", "UWB Device"),
         )
         val ignored = mutableListOf<String>()
 
-        fun onConfigExchanged(peerId: String, uwbKey: String?) {
-            if (uwbKey != null) {
-                val prev = uwbKeyToPeer[uwbKey]
-                if (prev != null && prev != peerId) {
-                    ignored.add(peerId)
-                    devices.removeAll { it.id == peerId }
-                    return
-                }
-                uwbKeyToPeer[uwbKey] = peerId
+        fun onConfigExchanged(peerId: String, remote: UwbSessionConfig) {
+            val key = DeviceDiscoveryManager.identityKeyFor(remote) ?: return
+            val prev = identityKeyToPeer[key]
+            if (prev != null && prev != peerId) {
+                ignored.add(peerId)
+                devices.removeAll { it.id == peerId }
+                return
             }
+            identityKeyToPeer[key] = peerId
         }
 
-        onConfigExchanged("58:CD:3D:CF:63:7F", "094d") // seen via our GATT server (kept)
-        onConfigExchanged("43:E3:E1:1B:D4:97", "094d") // same phone, seen via our scan (ignored)
+        onConfigExchanged("58:CD:3D:CF:63:7F", phoneConfig(byteArrayOf(0x09, 0x4d), keyA)) // kept
+        onConfigExchanged("43:E3:E1:1B:D4:97", phoneConfig(byteArrayOf(0x05, 0x88.toByte()), keyA)) // same phone, other address
 
         assertEquals(1, devices.size)
         assertEquals("58:CD:3D:CF:63:7F", devices[0].id)
@@ -142,37 +148,29 @@ class DeviceDiscoveryManagerTest {
     }
 
     @Test
-    fun distinctUwbAddressesAreKeptSeparate() {
-        // Two real peers (or two accessories) with different UWB addresses must not be merged.
-        val uwbKeyToPeer = mutableMapOf<String, String>()
-        val devices = mutableListOf<NearbyDevice>()
-
-        fun onConfigExchanged(peerId: String, uwbKey: String?) {
-            if (uwbKey != null) uwbKeyToPeer[uwbKey] = peerId
-            if (devices.none { it.id == peerId }) devices.add(NearbyDevice(peerId, "UWB Device"))
-        }
-
-        onConfigExchanged("p1", "094d")
-        onConfigExchanged("p2", "0588")
-
-        assertEquals(2, devices.size)
+    fun distinctPhonesAreKeptSeparate() {
+        val a = DeviceDiscoveryManager.identityKeyFor(phoneConfig(byteArrayOf(0x09, 0x4d), keyA))
+        val b = DeviceDiscoveryManager.identityKeyFor(phoneConfig(byteArrayOf(0x05, 0x88.toByte()), keyB))
+        assertTrue(a != null && b != null && a != b)
     }
 
     @Test
-    fun emptyUwbAddressSkipsDedup() {
-        // iOS configs carry no UWB address (null key), so identity dedup is bypassed entirely.
-        val uwbKeyToPeer = mutableMapOf<String, String>()
-        val devices = mutableListOf<NearbyDevice>()
+    fun accessoriesKeyOnTheirAddressNotOurKey() {
+        // The "remote" config for an accessory is our own config with the accessory address patched
+        // in, so two accessories carry the same (our) session key. They must still be two devices.
+        val acc1 = UwbSessionConfig(1, 9, 11, byteArrayOf(0x11, 0x11), sessionKey = keyA, isAccessoryDevice = true)
+        val acc2 = UwbSessionConfig(1, 9, 11, byteArrayOf(0x22, 0x22), sessionKey = keyA, isAccessoryDevice = true)
+        val k1 = DeviceDiscoveryManager.identityKeyFor(acc1)
+        val k2 = DeviceDiscoveryManager.identityKeyFor(acc2)
+        assertTrue(k1 != null && k2 != null && k1 != k2)
+        // And an accessory never collides with the phone whose key it echoes.
+        assertTrue(k1 != DeviceDiscoveryManager.identityKeyFor(phoneConfig(byteArrayOf(0x11, 0x11), keyA)))
+    }
 
-        fun onConfigExchanged(peerId: String, uwbKey: String?) {
-            if (uwbKey != null) uwbKeyToPeer[uwbKey] = peerId
-            if (devices.none { it.id == peerId }) devices.add(NearbyDevice(peerId, "UWB Device"))
-        }
-
-        onConfigExchanged("uuid-A", null)
-        onConfigExchanged("uuid-B", null)
-
-        assertEquals(2, devices.size)
-        assertTrue(uwbKeyToPeer.isEmpty())
+    @Test
+    fun iosConfigsHaveNoIdentityKey() {
+        // iOS configs carry neither a UWB address nor a key, so identity dedup is bypassed entirely.
+        val ios = UwbSessionConfig(0, 0, 0, ByteArray(0), discoveryToken = byteArrayOf(1, 2, 3))
+        assertNull(DeviceDiscoveryManager.identityKeyFor(ios))
     }
 }

--- a/uwbmodule/src/commonTest/kotlin/com/dustedrob/uwb/UwbSessionConfigTest.kt
+++ b/uwbmodule/src/commonTest/kotlin/com/dustedrob/uwb/UwbSessionConfigTest.kt
@@ -384,4 +384,40 @@ class UwbSessionConfigTest {
         assertNull(restored.sessionKey)
         assertNull(restored.accessoryData)
     }
+
+    // -- Pairwise session id (one session per peer) --
+
+    @Test
+    fun sessionIdForAgreesOnBothEnds() {
+        // The controller folds (its controller addr, peer's controlee addr); the controlee folds
+        // (peer's controller addr, its own controlee addr). Same inputs, same id, no round trip.
+        val controllerAddr = byteArrayOf(0x12, 0x34)
+        val controleeAddr = byteArrayOf(0x09, 0x4d.toByte())
+        val onController = UwbSessionConfig.sessionIdFor(controllerAddr, controleeAddr)
+        val onControlee = UwbSessionConfig.sessionIdFor(controllerAddr.copyOf(), controleeAddr.copyOf())
+        assertEquals(onController, onControlee)
+    }
+
+    @Test
+    fun sessionIdForDiffersPerPeer() {
+        // A phone that is controller to two peers needs two distinct ids on the same radio.
+        val myController = byteArrayOf(0x12, 0x34)
+        val peerA = byteArrayOf(0x09, 0x4d.toByte())
+        val peerB = byteArrayOf(0x05, 0x88.toByte())
+        assertTrue(UwbSessionConfig.sessionIdFor(myController, peerA) != UwbSessionConfig.sessionIdFor(myController, peerB))
+    }
+
+    @Test
+    fun sessionIdForIsRoleOrdered() {
+        // Swapping the roles is a different session; the order encodes who is controller.
+        val a = byteArrayOf(0x12, 0x34)
+        val b = byteArrayOf(0x09, 0x4d.toByte())
+        assertTrue(UwbSessionConfig.sessionIdFor(a, b) != UwbSessionConfig.sessionIdFor(b, a))
+    }
+
+    @Test
+    fun sessionIdForIsNeverZero() {
+        // 0 tells the stack to derive its own id, which the two ends would then not share.
+        assertTrue(UwbSessionConfig.sessionIdFor(ByteArray(0), ByteArray(0)) != 0)
+    }
 }

--- a/uwbmodule/src/iosMain/kotlin/BleManager.kt
+++ b/uwbmodule/src/iosMain/kotlin/BleManager.kt
@@ -47,6 +47,8 @@ actual class BleManager(
     private fun serverProfiles(): List<UwbProfile> =
         config.profiles.filter { it.exchange == ExchangeProtocol.ReadWrite && it.readFromUuid != null }
 
+
+
     /** Deliver a peer's serialized config to the app (single entry point, no duplicate dispatch). */
     private fun deliverRemoteConfig(peerId: String, bytes: ByteArray?) {
         val remoteConfig = bytes?.let { UwbSessionConfig.fromByteArray(it, false) }
@@ -114,6 +116,8 @@ actual class BleManager(
                 if (scanWhenReady) {
                     scanWhenReady = false
                     central.scanForPeripheralsWithServices(scanServiceUuids(), null)
+                    /* stop scanning after a few seconds */
+                    setTimeout(ScanTime, { stopScanning() })
                     NSLog("BleManager: Deferred scan started")
                 }
             } else {
@@ -127,6 +131,7 @@ actual class BleManager(
             advertisementData: Map<Any?, *>,
             RSSI: NSNumber
         ) {
+            NSLog(("did discover uuid=${didDiscoverPeripheral.identifier.UUIDString}"))
             val deviceId = didDiscoverPeripheral.identifier.UUIDString
             if (discoveredPeripherals[deviceId] == null) {
                 val deviceName = didDiscoverPeripheral.name ?: "Unknown Device"
@@ -139,16 +144,33 @@ actual class BleManager(
                 // 16-bit (e.g. FFF0) vs full 128-bit base UUIDs, so no string slicing is needed.
                 config.profiles.forEach { p ->
                     val target = CBUUID.UUIDWithString(p.advertisedUuid)
-                    if (serviceUuids.any { it == target }) {
+                    // if there is a UUID mask specified
+                    if(p.advertisedUUIDMask != "*") {
+                        NSLog("Have UUID filter for profile ${p.name} = ${p.advertisedUUIDMask}")
+                        for( id in serviceUuids) {
+                            NSLog("checking serviceid ${id.UUIDString}")
+                            if (createUUIDFilter(p.advertisedUUIDMask).matches(id.UUIDString)) {
+                                NSLog((" UUID matches filter = ${p.advertisedUUIDMask}"))
+                                // if good
+                                profile = p
+                                break
+                            }
+                        }
+                    } else if (serviceUuids.any { it == target }) {
                         profile = p
                     }
                 }
-
-                // Cache peripheral (must keep strong reference for connection)
-                discoveredPeripherals[deviceId] = AccessoryDevice(didDiscoverPeripheral, profile)
-                uwbManager.createConnectionConfig(deviceId, profile?.exchange == ExchangeProtocol.AccessoryNotify)
-                NSLog("BleManager: Discovered $deviceName ($deviceId) profile=${profile?.name}")
-                deviceDiscoveredCallback?.invoke(deviceId, deviceName)
+                if(profile != null) {
+                    // Cache peripheral (must keep strong reference for connection)
+                    discoveredPeripherals[deviceId] =
+                        AccessoryDevice(didDiscoverPeripheral, profile)
+                    uwbManager.createConnectionConfig(
+                        deviceId,
+                        profile.exchange == ExchangeProtocol.AccessoryNotify
+                    )
+                    NSLog("BleManager: Discovered $deviceName ($deviceId) profile=${profile?.name}")
+                    deviceDiscoveredCallback?.invoke(deviceId, deviceName)
+                }
             }
         }
 
@@ -408,19 +430,30 @@ actual class BleManager(
 
     // iOS uses all profiles: accessory ranging here is Apple's standard NI Accessory Protocol,
     // which is not gated by BleDiscoveryConfig.enableAndroidAccessoryProtocol (that flag is Android-only).
-    private fun scanServiceUuids(): List<CBUUID> =
-        config.profiles.map { CBUUID.UUIDWithString(it.advertisedUuid) }
+    private fun scanServiceUuids(): List<CBUUID>? {
+        var uuidList: List<CBUUID>? = null
+        val hasMask=config.profiles.any {
+            it.advertisedUUIDMask != "*"
+        }
+        if(!hasMask)
+            uuidList=config.profiles.map { CBUUID.UUIDWithString(it.advertisedUuid) }
+        return uuidList
+    }
 
     actual fun startScanning() {
         val central = centralManager ?: CBCentralManager(centralDelegate, null).also {
             centralManager = it
         }
-
+        val hasMask: Boolean = config.profiles.any {
+            it.advertisedUUIDMask!="*"
+        }
         if (central.state == CBManagerStatePoweredOn) {
             val options = mapOf<Any?, Any?>(
-                CBCentralManagerScanOptionAllowDuplicatesKey to NSNumber(false)
+                CBCentralManagerScanOptionAllowDuplicatesKey to NSNumber(true)
             )
             central.scanForPeripheralsWithServices(scanServiceUuids(), options)
+            /* stop scanning after a few seconds */
+            setTimeout(5000, { stopScanning() })
             NSLog("BleManager: Scan started immediately")
         } else {
             scanWhenReady = true
@@ -488,6 +521,7 @@ actual class BleManager(
 
     /** Adds the first hosted profile's service; the rest are chained via the didAddService delegate. */
     private fun addAllGattServices() {
+        NSLog(("Add services"))
         serverProfiles().firstOrNull()?.let { addGattService(it) }
     }
 

--- a/uwbmodule/src/iosMain/kotlin/MultiplatformUwbManager.ios.kt
+++ b/uwbmodule/src/iosMain/kotlin/MultiplatformUwbManager.ios.kt
@@ -17,6 +17,7 @@ import platform.NearbyInteraction.NIAlgorithmConvergenceStatusReasonInsufficient
 import platform.NearbyInteraction.NIAlgorithmConvergenceStatusReasonInsufficientLighting
 import platform.NearbyInteraction.NIAlgorithmConvergenceStatusReasonInsufficientMovement
 import platform.NearbyInteraction.NIAlgorithmConvergenceStatusReasonInsufficientVerticalSweep
+import platform.NearbyInteraction.NIConfiguration
 import platform.NearbyInteraction.NIDiscoveryToken
 import platform.NearbyInteraction.NINearbyAccessoryConfiguration
 import platform.NearbyInteraction.NINearbyObject
@@ -32,7 +33,7 @@ import platform.darwin.dispatch_get_main_queue
 actual class MultiplatformUwbManager {
 
     private var rangingCallback: ((String, Double, Double?, Double?) -> Unit)? = null
-    private var errorCallback: ((String) -> Unit)? = null
+    private var errorCallback: ((String?, String) -> Unit)? = null
 
     /** Outbound channel to write data back to a peer over BLE (wired to BleManager.sendToPeer). */
     private var sendToPeerCallback: ((String, ByteArray) -> Unit)? = null
@@ -59,9 +60,18 @@ actual class MultiplatformUwbManager {
     /** Strong reference to each session's delegate; NISession.delegate is weak. */
     private val activeDelegates = mutableMapOf<NISession, SessionDelegate>()
 
+    /**
+     * The configuration each peer's session is running, so a suspended session can be re-run when
+     * the suspension ends (NI requires `runWithConfiguration` again; it does not resume by itself).
+     */
+    private val peerConfigs = mutableMapOf<String, NIConfiguration>()
+
+    private fun peerIdFor(session: NISession): String =
+        peerSessions.entries.firstOrNull { it.value == session }?.key ?: "unknown"
+
      actual suspend fun initialize() {
         if (!NISession.isSupported()) {
-            errorCallback?.invoke("NearbyInteraction not supported on this device")
+            errorCallback?.invoke(null, "NearbyInteraction not supported on this device")
             return
         }
     }
@@ -131,7 +141,7 @@ actual class MultiplatformUwbManager {
             val config = try {
                 NINearbyAccessoryConfiguration(accessoryData.toNSData(), null)
             } catch (e: Exception) {
-                errorCallback?.invoke("Failed to build accessory configuration for $peerId: ${e.message}")
+                errorCallback?.invoke(peerId, "Failed to build accessory configuration for $peerId: ${e.message}")
                 return
             }
             // check for camera assistance in later iOS systems
@@ -149,20 +159,21 @@ actual class MultiplatformUwbManager {
             NSLog("UwbManager: Starting accessory ranging with $peerId ")
             val session = peerSessions[peerId]
             if (session == null) {
-                errorCallback?.invoke("No NISession for $peerId; createConnectionConfig must run first")
+                errorCallback?.invoke(peerId, "No NISession for $peerId; createConnectionConfig must run first")
                 return
             }
             accessoryPeers.add(peerId)
             // NISession.delegate is weak, so hold each session's delegate strongly per session.
             val delegate = activeDelegates[session] ?: SessionDelegate().also { activeDelegates[session] = it }
             session.delegate = delegate
+            peerConfigs[peerId] = config
             session.runWithConfiguration(config)
             return
         }
 
         val tokenBytes = remoteConfig.discoveryToken
         if (tokenBytes == null || tokenBytes.isEmpty()) {
-            errorCallback?.invoke("No discovery token in remote config for $peerId")
+            errorCallback?.invoke(peerId, "No discovery token in remote config for $peerId")
             return
         }
 
@@ -175,12 +186,12 @@ actual class MultiplatformUwbManager {
                 error = null
             ) as? NIDiscoveryToken
         } catch (e: Exception) {
-            errorCallback?.invoke("Failed to deserialize peer token for $peerId: ${e.message}")
+            errorCallback?.invoke(peerId, "Failed to deserialize peer token for $peerId: ${e.message}")
             return
         }
 
         if (peerToken == null) {
-            errorCallback?.invoke("Failed to deserialize discovery token for $peerId")
+            errorCallback?.invoke(peerId, "Failed to deserialize discovery token for $peerId")
             return
         }
 
@@ -201,25 +212,33 @@ actual class MultiplatformUwbManager {
         NSLog("UwbManager: Starting ranging with $peerId")
         val session = peerSessions[peerId]
         if (session == null) {
-            errorCallback?.invoke("No NISession for $peerId; createConnectionConfig must run first")
+            errorCallback?.invoke(peerId, "No NISession for $peerId; createConnectionConfig must run first")
             return
         }
         // NISession.delegate is weak, so hold each session's delegate strongly per session.
         val delegate = activeDelegates[session] ?: SessionDelegate().also { activeDelegates[session] = it }
         session.delegate = delegate
+        peerConfigs[peerId] = config
         session.runWithConfiguration(config)
     }
 
     actual suspend fun stopRanging(peerId: String) {
+        val session = peerSessions[peerId]
+        session?.pause()
+        forgetPeer(peerId)
+        NSLog("UwbManager: Paused session for $peerId")
+    }
+
+    /**
+     * Drop every per-peer entry for one peer, leaving the other sessions untouched. The config goes
+     * too, so a re-discovery mints a fresh session and token instead of reusing a dead one.
+     */
+    private fun forgetPeer(peerId: String) {
         activePeers.remove(peerId)
         accessoryPeers.remove(peerId)
-        val session = peerSessions.remove(peerId)
-        if (session != null) {
-            session.pause()
-            activeDelegates.remove(session)
-        }
+        peerConfigs.remove(peerId)
+        peerSessions.remove(peerId)?.let { activeDelegates.remove(it) }
         connectionConfigs.remove(peerId)
-        NSLog("UwbManager: Paused session for $peerId")
     }
 
     actual fun setRangingCallback(callback: (peerId: String, distance: Double, azimuth: Double?, elevation: Double?) -> Unit) {
@@ -230,7 +249,7 @@ actual class MultiplatformUwbManager {
         sendToPeerCallback = callback
     }
 
-    actual fun setErrorCallback(callback: (error: String) -> Unit) {
+    actual fun setErrorCallback(callback: (peerId: String?, error: String) -> Unit) {
         errorCallback = callback
     }
 
@@ -240,6 +259,7 @@ actual class MultiplatformUwbManager {
         peerSessions.clear()
         accessoryPeers.clear()
         activeDelegates.clear()
+        peerConfigs.clear()
         connectionConfigs.clear()
         NSLog("UwbManager: Cleanup completed")
     }
@@ -250,20 +270,13 @@ actual class MultiplatformUwbManager {
 
         override fun session(session: NISession, didUpdateNearbyObjects: List<*>) {
             dispatchToMain {
-                // Accessory objects aren't in activePeers (keyed by peer tokens), so fall
-                // back to the tracked accessory peer.
-                val peerId:String = peerSessions.entries
-                    .firstOrNull { it.value == session }?.key ?: "unknown"
+                // Sessions are per peer, so the session identity is the peer identity (accessory
+                // objects aren't in activePeers, which is keyed by peer tokens).
+                val peerId = peerIdFor(session)
                 didUpdateNearbyObjects.forEach { obj ->
-                    NSLog("didUpdate entered for $peerId")
                     if (obj is NINearbyObject) {
                         val distance = obj.distance.toDouble()
                         if (!distance.isNaN()) {
-                            // Accessory objects aren't in activePeers (keyed by peer tokens), so fall
-                            // back to the tracked accessory peer.
-                            val peerId:String = peerSessions.entries
-                                .firstOrNull { it.value == session }?.key ?: "unknown"
-
                             // Azimuth (`horizontalAngle`) is iOS 16+ and is NaN until camera-assistance
                             // convergence, so only emit it when available and valid. NearbyInteraction
                             // reports it in radians; convert to degrees to match the module contract
@@ -280,7 +293,6 @@ actual class MultiplatformUwbManager {
                             // NearbyInteraction exposes no elevation angle — `verticalDirectionEstimate`
                             // is a direction category (above/below/same), not a measurement — so we
                             // leave elevation null on iOS rather than emit a meaningless value.
-                            NSLog("sending callback info to $peerId")
                             rangingCallback?.invoke(peerId, distance, azimuth, null)
                         }
                     }
@@ -294,14 +306,12 @@ actual class MultiplatformUwbManager {
             withReason: NINearbyObjectRemovalReason
         ) {
             dispatchToMain {
+                val peerId = peerIdFor(session)
                 didRemoveNearbyObjects.forEach { obj ->
                     if (obj is NINearbyObject) {
-                        val peerId:String = peerSessions.entries
-                            .firstOrNull { it.value == session }?.key ?: "unknown"
-                        peerId.let {
-                            activePeers.remove(it)
-                            NSLog("UwbManager: Peer $it removed, reason=$withReason")
-                        }
+                        activePeers.remove(peerId)
+                        NSLog("UwbManager: Peer $peerId removed, reason=$withReason")
+                        errorCallback?.invoke(peerId, "Peer $peerId out of range (reason=$withReason)")
                     }
                 }
             }
@@ -310,12 +320,11 @@ actual class MultiplatformUwbManager {
         override fun session(session: NISession, didInvalidateWithError: NSError) {
             dispatchToMain {
                 val msg = didInvalidateWithError.localizedDescription
-                NSLog("UwbManager: Session invalidated: $msg")
-                errorCallback?.invoke("NI Session error: $msg")
-                activePeers.clear()
-                peerSessions.clear()
-                accessoryPeers.clear()
-                activeDelegates.clear()
+                // Only this peer's session died; the others keep ranging.
+                val peerId = peerIdFor(session)
+                NSLog("UwbManager: Session invalidated for $peerId: $msg")
+                errorCallback?.invoke(peerId, "NI Session error: $msg")
+                forgetPeer(peerId)
             }
         }
 
@@ -327,8 +336,7 @@ actual class MultiplatformUwbManager {
             NSLog("did generate entered")
             // Accessory ranging: NI produced the data the accessory needs to start. Send it back over
             // BLE, prefixed with the configure-and-start message id.
-            val peerId:String = peerSessions.entries
-                .firstOrNull { it.value == session }?.key ?: "unknown"
+            val peerId = peerIdFor(session)
 
             val payload = byteArrayOf(NI_ACCESSORY_CONFIGURE_AND_START) + didGenerateShareableConfigurationData.toByteArray()
             NSLog("UwbManager: sending configure-and-start to $peerId (${payload.size} bytes)")
@@ -374,30 +382,30 @@ actual class MultiplatformUwbManager {
         }
 
         override fun sessionDidStartRunning(session: NISession) {
-            val peerId:String = peerSessions.entries
-                .firstOrNull { it.value == session }?.key ?: "unknown"
-            NSLog("UwbManager: Session started running for ${peerId}")
+            NSLog("UwbManager: Session started running for ${peerIdFor(session)}")
         }
 
         override fun sessionWasSuspended(session: NISession) {
-            val peerId:String = peerSessions.entries
-                .firstOrNull { it.value == session }?.key ?: "unknown"
+            val peerId = peerIdFor(session)
             NSLog("UwbManager: Session suspended for ${peerId}")
-            // Only accessories understand the BLE stop command; phone-to-phone peers don't.
-            if (peerId in accessoryPeers) {
-                sendToPeerCallback?.invoke(peerId, byteArrayOf(NI_ACCESSORY_STOP))
-            }
+            // Suspension is transient (backgrounding, or NI juggling several sessions), so do not
+            // tell an accessory to stop here: that made the suspension permanent, and the accessory
+            // only learns about a real stop from stopRanging. We re-run when the suspension ends.
             dispatchToMain {
-                errorCallback?.invoke("NI Session was suspended for $peerId")
+                errorCallback?.invoke(peerId, "NI Session was suspended for $peerId")
             }
         }
 
         override fun sessionSuspensionEnded(session: NISession) {
-            val peerId:String = peerSessions.entries
-                .firstOrNull { it.value == session }?.key ?: "unknown"
+            val peerId = peerIdFor(session)
             NSLog("UwbManager: Session suspension ended for $peerId")
-            // Re-run with existing config if we have active peers
-            // The session needs to be re-configured after suspension
+            // NI does not resume by itself; the session has to be run with its configuration again.
+            val config = peerConfigs[peerId]
+            if (config != null) {
+                session.runWithConfiguration(config)
+            } else {
+                NSLog("UwbManager: No stored configuration for $peerId; cannot resume")
+            }
         }
     }
 


### PR DESCRIPTION
Add support for UUID scan masking 
Closes #14 

the DiscoveryViewModel has all three profiles, including with the mask

mask is 

in a position # = number (0-9) 
                      . =  any char (0-9, A-F)
                            otherwise text for exact match

Example
the advertised entry in profile =  11000000-27B9-42F0-82AA-2E951747BBF9 
device actually advertising 31000000-27B9-42F0-82AA-2E951747BBF9 // this won't match above, but should
the mask = "####...#-27B9-42F0-82AA-2E951747BBF9"

this means 4 digits, 3 don't care, 1 digit, rest match exactly
builds a regex string , 

because this masking requires not specifying UUIDs on blescan (apple), the discover routine gets pounded with 
unnecessary  calls.. so added timeout (default 5 seconds)

filterbuilder, settimeout and default time are in commonMain/BleManager.kt, shared code..
android needed a JVM fle name prefix to build.. 

my device can/does change its UUID live based on internal logic, done this way to not have to connect to determine properties
(connecting blocks other users in the same room)